### PR TITLE
fix: use node inspect to handle object types when running reporter

### DIFF
--- a/.changeset/mighty-files-decide.md
+++ b/.changeset/mighty-files-decide.md
@@ -1,0 +1,5 @@
+---
+"evalite": minor
+---
+
+Improved report table formatting for objects.

--- a/.changeset/mighty-files-decide.md
+++ b/.changeset/mighty-files-decide.md
@@ -1,5 +1,5 @@
 ---
-"evalite": minor
+"evalite": patch
 ---
 
 Improved report table formatting for objects.

--- a/packages/evalite-tests/vitest.config.ts
+++ b/packages/evalite-tests/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    maxConcurrency: process.env.CI ? 2 : 5,
+    maxConcurrency: process.env.CI ? 1 : 5,
   },
 });

--- a/packages/evalite/src/reporter.ts
+++ b/packages/evalite/src/reporter.ts
@@ -5,6 +5,7 @@ import { appendEvalsToJsonDb, type Evalite } from "@evalite/core";
 import { table } from "table";
 import c from "tinyrainbow";
 import { average, sum } from "./utils.js";
+import { inspect } from "util";
 
 export interface EvaliteReporterOptions {
   jsonDbLocation: string;
@@ -230,12 +231,26 @@ export default class EvaliteReporter extends BasicReporter {
             c.cyan(c.bold("Output")),
             c.cyan(c.bold("Score")),
           ],
-          ...props.map((p) => [p.input, p.output, displayScore(p.score)]),
+          ...props.map((p) => [
+            inspect(p.input, {
+              colors: true,
+              depth: null,
+              breakLength: colWidth,
+              compact: true,
+            }),
+            inspect(p.output, {
+              colors: true,
+              depth: null,
+              breakLength: colWidth,
+              compact: true,
+            }),
+            displayScore(p.score),
+          ]),
         ],
         {
           columns: [
-            { width: colWidth, wrapWord: true },
-            { width: colWidth, wrapWord: true },
+            { width: colWidth, wrapWord: false },
+            { width: colWidth, wrapWord: false },
             { width: scoreWidth },
           ],
         }

--- a/packages/evalite/src/reporter.ts
+++ b/packages/evalite/src/reporter.ts
@@ -237,6 +237,7 @@ export default class EvaliteReporter extends BasicReporter {
                   colors: true,
                   depth: null,
                   breakLength: colWidth,
+                  numericSeparator: true,
                   compact: true,
                 })
               : p.input,
@@ -245,6 +246,7 @@ export default class EvaliteReporter extends BasicReporter {
                   colors: true,
                   depth: null,
                   breakLength: colWidth,
+                  numericSeparator: true,
                   compact: true,
                 })
               : p.output,

--- a/packages/evalite/src/reporter.ts
+++ b/packages/evalite/src/reporter.ts
@@ -232,25 +232,29 @@ export default class EvaliteReporter extends BasicReporter {
             c.cyan(c.bold("Score")),
           ],
           ...props.map((p) => [
-            inspect(p.input, {
-              colors: true,
-              depth: null,
-              breakLength: colWidth,
-              compact: true,
-            }),
-            inspect(p.output, {
-              colors: true,
-              depth: null,
-              breakLength: colWidth,
-              compact: true,
-            }),
+            typeof p.input === "object"
+              ? inspect(p.input, {
+                  colors: true,
+                  depth: null,
+                  breakLength: colWidth,
+                  compact: true,
+                })
+              : p.input,
+            typeof p.output === "object"
+              ? inspect(p.output, {
+                  colors: true,
+                  depth: null,
+                  breakLength: colWidth,
+                  compact: true,
+                })
+              : p.output,
             displayScore(p.score),
           ]),
         ],
         {
           columns: [
-            { width: colWidth, wrapWord: false },
-            { width: colWidth, wrapWord: false },
+            { width: colWidth, wrapWord: typeof props[0]?.input === "string" },
+            { width: colWidth, wrapWord: typeof props[0]?.output === "string" },
             { width: scoreWidth },
           ],
         }


### PR DESCRIPTION
Hi @mattpocock - curious if this is something that you'd like to support with evalite. I am going to be doing a lot of testing on structured data and I noticed that when running the reporter, it's not printing out the objects as expected.

Before:

![CleanShot 2024-12-07 at 10 33 54](https://github.com/user-attachments/assets/f3f230c5-bb0e-4838-9bbd-aaaa4c3d1db8)

After
![CleanShot 2024-12-07 at 10 29 12](https://github.com/user-attachments/assets/f301339b-3311-4639-9e7f-6a5e003a98cb)

P.S. - Also, curious if there's a way to specify globs - I noticed there's a subcommand with `<glob>` but I haven't been able to get path filtering working. Is that supported today? Was wanting to run evals for just 1 file so that I could see the report table.