### PR TITLE
fix: add quit listener

### DIFF
--- a/packages/evalite/src/run-vitest.ts
+++ b/packages/evalite/src/run-vitest.ts
@@ -96,4 +96,14 @@ export const runVitest = async (opts: {
   if (!vitest.shouldKeepServer()) {
     return await vitest.exit();
   }
+
+  if (opts.mode === "watch-for-file-changes") {
+    process.stdin.setRawMode(true);
+    process.stdin.on("data", async (data) => {
+      if (data.toString() === "q") {
+        await vitest.exit();
+        process.exit(0);
+      }
+    });
+  }
 };


### PR DESCRIPTION
The "press q to quite" listener isn't working, I think this should fix it, but maybe there's a better way to handle this without re-configuring all of Vitest's defaults?