### PR TITLE
patch: add version flag

### DIFF
--- a/.changeset/rich-maps-sin.md
+++ b/.changeset/rich-maps-sin.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Add --version flag

--- a/packages/evalite/src/command.ts
+++ b/packages/evalite/src/command.ts
@@ -1,11 +1,16 @@
 import { Command } from "commander";
 import { runVitest } from "./run-vitest.js";
 
+import { createRequire } from "node:module";
+const packageJson = createRequire(import.meta.url)("../package.json") as typeof import("../package.json");
+
 export const createProgram = (commands: {
   watch: (path: string | undefined) => void;
   runOnceAtPath: (path: string | undefined) => void;
 }) => {
   const program = new Command();
+
+  program.version(packageJson.version);
 
   program
     .description("Run evals once and exit")


### PR DESCRIPTION
I wanted to check to see if I was correctly accessing my local version of evalite and noticed there was no version command, so this adds a --version and -V command

I could have used `import packageJson from '../package.json' as { assert: 'json' }` but that throws an experimental warning on Node 20 and I can't see any details in the project yet about which engines you want to support fully, which makes the logs a bit noisy.

```
> evalite --version
0.8.2

> evalite --help
Usage: evalite [options] [command] [path]

Run evals at specified path once and exit

Arguments:
  path           path to eval file

Options:
  -V, --version  output the version number
  -h, --help     display help for command

Commands:
  watch [path]   Watch evals for file changes
