### PR TITLE
add pkg pr new support

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,45 @@
+name: Preview
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "packages/**"
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "pnpm"
+      
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm build
+
+      - name: Get affected packages paths
+        id: changed_packages
+        if: github.ref != 'refs/heads/main'
+        env:
+          TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          packages=$(pnpx turbo ls --affected --output=json \
+            | jq -r '.packages.items[].path' \
+            | paste -sd ',' - \
+            | sed 's/^/"/;s/$/"/;s/,/" "/g')
+          if [ -z "$packages" ]; then
+            echo "No packages changed"
+            echo "packages=" >> $GITHUB_OUTPUT
+          else
+            echo "Detected packages: $packages"
+            echo "packages=$packages" >> $GITHUB_OUTPUT
+          fi
+      - name: Publish preview releases
+        if: github.ref != 'refs/heads/main' && steps.changed_packages.outputs.packages != ''
+        run: pnpx pkg-pr-new publish ${{ steps.changed_packages.outputs.packages }}


### PR DESCRIPTION
I mostly just wanted this for my fork but making a PR in case you'd like it here too

This adds a GitHub Action for installable preview releases via [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new), which should make it easier to test and use PRs before they make it into the main release

You'd have to install the [GitHub Application](https://github.com/apps/pkg-pr-new) first, and then this action should take care of generating the release and adding install links to each PR