### PR TITLE
Allow the content to stretch to full width

### DIFF
--- a/.changeset/seven-apes-enjoy.md
+++ b/.changeset/seven-apes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Allow the content to stretch to full width

--- a/apps/evalite-ui/app/components/page-layout.tsx
+++ b/apps/evalite-ui/app/components/page-layout.tsx
@@ -18,7 +18,7 @@ export const InnerPageLayout = ({
   children: React.ReactNode;
 }) => {
   return (
-    <div className="flex flex-col bg-background relative flex-1 min-h-svh max-w-7xl">
+    <div className="flex flex-col bg-background relative flex-1 min-h-svh">
       <header className="sticky top-0 flex h-14 shrink-0 items-center gap-2 bg-background z-10">
         <div className="flex flex-1 items-center gap-2 px-3">
           <SidebarTrigger />


### PR DESCRIPTION
This PR removes the fixed max-w-7xl constraint from our main page container so it can expand to the full viewport width. On wide monitors, this prevents columns from being hidden off-screen and eliminates constant horizontal scrolling when inspecting large tables.

🎯 Why
- Leverage large screens
On 27″+ displays, the extra horizontal space was being wasted by the max-w-7xl wrapper. Removing it makes full use of your monitor for data-dense views.

- Improved table usability
All table columns (including previously hidden ones) are now visible without manual horizontal scrolling.

- Minimal impact
Small CSS tweak with no visual regressions on narrow viewports.