### PR TITLE
Ensure cell content respects column width and add padding

### DIFF
--- a/.changeset/shaggy-poems-enjoy.md
+++ b/.changeset/shaggy-poems-enjoy.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Fixed a bug where the renderTable function would sometimes error when containing emoji's.

--- a/packages/evalite/src/reporter.ts
+++ b/packages/evalite/src/reporter.ts
@@ -564,6 +564,9 @@ export default class EvaliteReporter extends BasicReporter {
             ...columns.map((col) => ({
               width: colWidth,
               wrapWord: typeof col.value === "string",
+              truncate: colWidth - 2,
+              paddingLeft: 1,
+              paddingRight: 1
             })),
             { width: scoreWidth },
           ],


### PR DESCRIPTION
## 🚨 Problem

When table cells contain long strings, the `table` package throws an error:

Error: Subject parameter value width cannot be greater than the container width.
❯ alignString …/node_modules/table/dist/src/alignString.js:42:15
❯ …

In our reporter (`EvaliteReporter`), we pass each column’s raw value directly to the table renderer. If a string is longer than the specified column width, the renderer crashes. There is no wrapping, truncation, or padding, so very wide content simply blows up the layout.

---

## 💡 Proposed Solution

1. **Truncate** any string value so its display width is at most `(colWidth – 2)`  
2. **Add 1 character of padding** on both left and right of each cell  
3. Preserve existing behavior for non-string values  

These changes ensure:

- **No more “value width > container width” errors.**  
- **Consistent padding** for better visuals.  
- Backwards‐compatible behavior for numbers, booleans, etc.

⸻

📚 Context
	•	Source of error: [alignString in the table package`](https://github.com/gajus/table/blob/master/src/alignString.js#L42)
	•	A similar fix for padding/truncation can be found in upstream projects that wrap table.

⸻

Please let me know if any additional tests or examples would be helpful! 🎉