### PR TITLE
Handle onTaskUpdate method being undefined in Vitest 3

### DIFF
--- a/.changeset/blue-boxes-raise.md
+++ b/.changeset/blue-boxes-raise.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Handle onTaskUpdate method being undefined in Vitest 3

--- a/packages/evalite/src/reporter.ts
+++ b/packages/evalite/src/reporter.ts
@@ -645,7 +645,7 @@ export default class EvaliteReporter extends BasicReporter {
 
     startingTests.forEach((test) => this.onTestStart(test));
 
-    super.onTaskUpdate(packs);
+    super.onTaskUpdate?.(packs);
   }
 }
 


### PR DESCRIPTION
Fixes #126 

Fixes a bug where the onTaskUpdate method is `undefined` in Vitest 3, while in Vitest 2 it exists.

I solved it by checking if the onTaskUpdate method exists, with the optional chaining operator.

[More detailed explanation of the bug](https://github.com/mattpocock/evalite/issues/126#issuecomment-2841555448).