### PR TITLE
fix: exit code should be set to 1 for any failing tasks or timeouts

### DIFF
--- a/.changeset/breezy-shoes-knock.md
+++ b/.changeset/breezy-shoes-knock.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Exit code should be set to 1 for any failing tasks or timeouts

--- a/packages/evalite-tests/tests/ai-sdk-traces.test.ts
+++ b/packages/evalite-tests/tests/ai-sdk-traces.test.ts
@@ -1,12 +1,14 @@
 import { createDatabase, getEvalsAsRecord } from "evalite/db";
 import { runVitest } from "evalite/runner";
-import { assert, expect, it } from "vitest";
+import { assert, expect, it, vitest } from "vitest";
 import { captureStdout, loadFixture } from "./test-utils.js";
 
 it("Should report traces from generateText using traceAISDKModel", async () => {
   using fixture = loadFixture("ai-sdk-traces");
 
   const captured = captureStdout();
+  const exit = vitest.fn();
+  globalThis.process.exit = exit as any;
 
   await runVitest({
     cwd: fixture.dir,
@@ -34,6 +36,8 @@ it("Should report traces from generateText using traceAISDKModel", async () => {
       },
     ],
   });
+
+  expect(exit).toHaveBeenCalledWith(1);
 });
 
 it("Should report traces from streamText using traceAISDKModel", async () => {

--- a/packages/evalite-tests/tests/failing.test.ts
+++ b/packages/evalite-tests/tests/failing.test.ts
@@ -1,12 +1,32 @@
 import { createDatabase, getEvalsAsRecord, type Db } from "evalite/db";
 import { runVitest } from "evalite/runner";
-import { expect, it } from "vitest";
+import { expect, it, vitest } from "vitest";
 import { captureStdout, loadFixture } from "./test-utils.js";
+
+it("Should set exitCode to 1 if there is a failing test", async () => {
+  using fixture = loadFixture("failing-test");
+
+  const captured = captureStdout();
+  const exit = vitest.fn();
+  globalThis.process.exit = exit as any;
+
+  await runVitest({
+    cwd: fixture.dir,
+    path: undefined,
+    testOutputWritable: captured.writable,
+    mode: "run-once-and-exit",
+  });
+
+  expect(captured.getOutput()).toContain("failed");
+  expect(exit).toHaveBeenCalledWith(1);
+});
 
 it("Should report a failing test", async () => {
   using fixture = loadFixture("failing-test");
 
   const captured = captureStdout();
+  const exit = vitest.fn();
+  globalThis.process.exit = exit as any;
 
   await runVitest({
     cwd: fixture.dir,
@@ -26,6 +46,8 @@ it("Should save the result AND eval as failed in the database", async () => {
   using fixture = loadFixture("failing-test");
 
   const captured = captureStdout();
+  const exit = vitest.fn();
+  globalThis.process.exit = exit as any;
 
   await runVitest({
     cwd: fixture.dir,

--- a/packages/evalite-tests/tests/timeout.test.ts
+++ b/packages/evalite-tests/tests/timeout.test.ts
@@ -1,12 +1,32 @@
-import { expect, it } from "vitest";
+import { expect, it, vitest } from "vitest";
 import { runVitest } from "evalite/runner";
 import { captureStdout, loadFixture } from "./test-utils.js";
 import { createDatabase, getEvalsAsRecord } from "evalite/db";
+
+it("Should set exitCode to 1 if there is a timeout", async () => {
+  using fixture = loadFixture("timeout");
+
+  const captured = captureStdout();
+  const exit = vitest.fn();
+  globalThis.process.exit = exit as any;
+
+  await runVitest({
+    cwd: fixture.dir,
+    path: undefined,
+    testOutputWritable: captured.writable,
+    mode: "run-once-and-exit",
+  });
+
+  expect(captured.getOutput()).toContain("timeout");
+  expect(exit).toHaveBeenCalledWith(1);
+});
 
 it("Should handle timeouts gracefully", async () => {
   using fixture = loadFixture("timeout");
 
   const captured = captureStdout();
+  const exit = vitest.fn();
+  globalThis.process.exit = exit as any;
 
   await runVitest({
     cwd: fixture.dir,
@@ -27,6 +47,8 @@ it("Should record timeout information in the database", async () => {
   using fixture = loadFixture("timeout");
 
   const captured = captureStdout();
+  const exit = vitest.fn();
+  globalThis.process.exit = exit as any;
 
   await runVitest({
     cwd: fixture.dir,

--- a/packages/evalite/src/reporter.ts
+++ b/packages/evalite/src/reporter.ts
@@ -427,6 +427,11 @@ export default class EvaliteReporter extends BasicReporter {
       ["      ", c.dim("Score"), "  ", scoreDisplay].join("")
     );
 
+    // Set exit code to 1 if there are any failed tasks (regardless of threshold)
+    if (failedTasks.length > 0) {
+      this.opts.modifyExitCode(1);
+    }
+
     if (typeof this.opts.scoreThreshold === "number") {
       let thresholdScoreSuffix = "";
 
@@ -436,7 +441,10 @@ export default class EvaliteReporter extends BasicReporter {
         this.didLastRunFailThreshold = "yes";
       } else {
         thresholdScoreSuffix = `${c.dim(` (passed)`)}`;
-        this.opts.modifyExitCode(0);
+        // Only set exit code to 0 if there are no failed tasks
+        if (failedTasks.length === 0) {
+          this.opts.modifyExitCode(0);
+        }
         this.didLastRunFailThreshold = "no";
       }
 
@@ -566,7 +574,7 @@ export default class EvaliteReporter extends BasicReporter {
               wrapWord: typeof col.value === "string",
               truncate: colWidth - 2,
               paddingLeft: 1,
-              paddingRight: 1
+              paddingRight: 1,
             })),
             { width: scoreWidth },
           ],


### PR DESCRIPTION
Hi @mattpocock, thanks for putting this together!

Trying it out I was surprised to see my CI passing despite the tool timing out and the eval not completing.

This was my quick attempt at rectifying that and adding some coverage