### PR TITLE
Include mts files

### DIFF
--- a/packages/evalite/src/run-vitest.ts
+++ b/packages/evalite/src/run-vitest.ts
@@ -48,7 +48,7 @@ export const runVitest = async (opts: {
       // Everything passed here cannot be
       // overridden by the user
       root: opts.cwd,
-      include: ["**/*.eval.ts"],
+      include: ["**/*.eval.?(m)ts"],
       watch: opts.mode === "watch-for-file-changes",
       reporters: [
         new EvaliteReporter({


### PR DESCRIPTION
I'm trying to set up evalite on a older repository and unfortunately I can't name the files `.ts` without adding `"type": "module"` to the package.json which then breaks other things