### PR TITLE
Add 'outputPath' cli option to evalite for exporting evaluations results to file

### DIFF
--- a/packages/evalite-tests/tests/output-path.test.ts
+++ b/packages/evalite-tests/tests/output-path.test.ts
@@ -1,0 +1,148 @@
+import { expect, it } from "vitest";
+import { runVitest } from "evalite/runner";
+import { captureStdout, loadFixture } from "./test-utils.js";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import path from "path";
+
+it("Should export results to JSON when outputPath is specified", async () => {
+  using fixture = loadFixture("basics");
+
+  const captured = captureStdout();
+  const outputPath = path.join(fixture.dir, "results.json");
+
+  await runVitest({
+    cwd: fixture.dir,
+    testOutputWritable: captured.writable,
+    mode: "run-once-and-exit",
+    outputPath,
+    path: undefined,
+  });
+
+  // Verify the file was created
+  expect(existsSync(outputPath)).toBe(true);
+
+  // Read and parse the JSON file
+  const fileContent = await readFile(outputPath, "utf-8");
+  const results = JSON.parse(fileContent);
+
+  // Verify the structure
+  expect(results).toHaveProperty("runId");
+  expect(results).toHaveProperty("runType");
+  expect(results).toHaveProperty("created_at");
+  expect(results).toHaveProperty("evals");
+
+  // Verify the run type
+  expect(results.runType).toBe("full");
+
+  // Verify evals array
+  expect(Array.isArray(results.evals)).toBe(true);
+  expect(results.evals.length).toBeGreaterThan(0);
+
+  // Verify each result has the expected properties
+  results.evals.forEach((result: any) => {
+    expect(result).toHaveProperty("id");
+    expect(result).toHaveProperty("eval_id");
+    expect(result).toHaveProperty("duration");
+    expect(result).toHaveProperty("input");
+    expect(result).toHaveProperty("output");
+    expect(result).toHaveProperty("status");
+    expect(result).toHaveProperty("created_at");
+    expect(result).toHaveProperty("col_order");
+    expect(result).toHaveProperty("average");
+    expect(result).toHaveProperty("scores");
+    expect(Array.isArray(result.scores)).toBe(true);
+  });
+});
+
+it("Should support relative output paths", async () => {
+  using fixture = loadFixture("basics");
+
+  const captured = captureStdout();
+  const relativeOutputPath = "output/test-results.json";
+
+  await runVitest({
+    cwd: fixture.dir,
+    testOutputWritable: captured.writable,
+    mode: "run-once-and-exit",
+    outputPath: relativeOutputPath,
+    path: undefined,
+  });
+
+  const absoluteOutputPath = path.join(fixture.dir, relativeOutputPath);
+
+  // Verify the file was created at the correct location
+  expect(existsSync(absoluteOutputPath)).toBe(true);
+
+  // Verify it's valid JSON
+  const fileContent = await readFile(absoluteOutputPath, "utf-8");
+  const results = JSON.parse(fileContent);
+
+  expect(results).toHaveProperty("evals");
+});
+
+it("Should create nested directories if they don't exist", async () => {
+  using fixture = loadFixture("basics");
+
+  const captured = captureStdout();
+  const nestedOutputPath = path.join(
+    fixture.dir,
+    "deeply",
+    "nested",
+    "path",
+    "results.json",
+  );
+
+  await runVitest({
+    cwd: fixture.dir,
+    testOutputWritable: captured.writable,
+    mode: "run-once-and-exit",
+    outputPath: nestedOutputPath,
+    path: undefined,
+  });
+
+  // Verify the file was created
+  expect(existsSync(nestedOutputPath)).toBe(true);
+
+  // Verify it contains valid data
+  const fileContent = await readFile(nestedOutputPath, "utf-8");
+  const results = JSON.parse(fileContent);
+
+  expect(results.evals.length).toBeGreaterThan(0);
+});
+
+it("Should include result scores in the output", async () => {
+  using fixture = loadFixture("basics");
+
+  const captured = captureStdout();
+  const outputPath = path.join(fixture.dir, "results.json");
+
+  await runVitest({
+    cwd: fixture.dir,
+    testOutputWritable: captured.writable,
+    mode: "run-once-and-exit",
+    outputPath,
+    path: undefined,
+  });
+
+  const fileContent = await readFile(outputPath, "utf-8");
+  const results = JSON.parse(fileContent);
+
+  // Verify that each result has an average score and individual scores
+  results.evals.forEach((result: any) => {
+    expect(typeof result.average).toBe("number");
+    expect(result.average).toBeGreaterThanOrEqual(0);
+    expect(result.average).toBeLessThanOrEqual(1);
+
+    expect(Array.isArray(result.scores)).toBe(true);
+    result.scores.forEach((score: any) => {
+      expect(score).toHaveProperty("id");
+      expect(score).toHaveProperty("result_id");
+      expect(score).toHaveProperty("name");
+      expect(score).toHaveProperty("score");
+      expect(typeof score.score).toBe("number");
+      expect(score.score).toBeGreaterThanOrEqual(0);
+      expect(score.score).toBeLessThanOrEqual(1);
+    });
+  });
+});

--- a/packages/evalite/src/command.ts
+++ b/packages/evalite/src/command.ts
@@ -13,6 +13,7 @@ const packageJson = createRequire(import.meta.url)(
 type ProgramOpts = {
   path: string | undefined;
   threshold: number | undefined;
+  outputPath: string | undefined;
 };
 
 const commonParameters = {
@@ -28,11 +29,19 @@ const commonParameters = {
         "Fails the process if the score is below threshold. Specified as 0-100. Default is 100.",
       optional: true,
     },
+    outputPath: {
+      kind: "parsed",
+      parse: String,
+      brief:
+        "Path to write test results in JSON format after evaluation completes.",
+      optional: true,
+    },
   },
 } as const;
 
 type Flags = {
   threshold: number | undefined;
+  outputPath: string | undefined;
 };
 
 export const createProgram = (commands: {
@@ -42,7 +51,7 @@ export const createProgram = (commands: {
   const runOnce = buildCommand({
     parameters: commonParameters,
     func: async (flags: Flags, path: string | undefined) => {
-      return commands.runOnceAtPath({ path, threshold: flags.threshold });
+      return commands.runOnceAtPath({ path, threshold: flags.threshold, outputPath: flags.outputPath });
     },
     docs: {
       brief: "Run evals at specified path once and exit",
@@ -52,7 +61,7 @@ export const createProgram = (commands: {
   const watch = buildCommand({
     parameters: commonParameters,
     func: (flags: Flags, path: string | undefined) => {
-      return commands.watch({ path, threshold: flags.threshold });
+      return commands.watch({ path, threshold: flags.threshold, outputPath: flags.outputPath });
     },
     docs: {
       brief: "Watch evals for file changes",
@@ -93,6 +102,7 @@ export const program = createProgram({
       scoreThreshold: path.threshold,
       cwd: undefined,
       mode: "watch-for-file-changes",
+      outputPath: path.outputPath,
     });
   },
   runOnceAtPath: (path) => {
@@ -101,6 +111,7 @@ export const program = createProgram({
       scoreThreshold: path.threshold,
       cwd: undefined,
       mode: "run-once-and-exit",
+      outputPath: path.outputPath,
     });
   },
 });


### PR DESCRIPTION
This pull request adds support for exporting evaluation results to a JSON file in the Evalite testing framework. It introduces a new `outputPath` option to the CLI, which allows users to specify where the results should be written after tests complete. The implementation ensures results are correctly structured, supports relative and nested paths, and includes detailed scoring information.

**CLI/Program Option Enhancements:**

* Added a new `outputPath` option to the CLI and program configuration, allowing users to specify a file path for exporting test results in JSON format. This option is now supported in both "run-once-and-exit" and "watch-for-file-changes" modes. [[1]](diffhunk://#diff-33136f9ad382a630fef7344e3febd4166fe57c657cf4f2af3fbe5a20b3609e04R16) [[2]](diffhunk://#diff-33136f9ad382a630fef7344e3febd4166fe57c657cf4f2af3fbe5a20b3609e04R32-R44) [[3]](diffhunk://#diff-33136f9ad382a630fef7344e3febd4166fe57c657cf4f2af3fbe5a20b3609e04L45-R54) [[4]](diffhunk://#diff-33136f9ad382a630fef7344e3febd4166fe57c657cf4f2af3fbe5a20b3609e04L55-R64) [[5]](diffhunk://#diff-33136f9ad382a630fef7344e3febd4166fe57c657cf4f2af3fbe5a20b3609e04R105) [[6]](diffhunk://#diff-33136f9ad382a630fef7344e3febd4166fe57c657cf4f2af3fbe5a20b3609e04R114)

**Core Functionality:**

* Implemented the `exportResultsToJSON` function in `run-vitest.ts`, which collects the most recent test run data, gathers results and scores, structures them, and writes them to the specified output path. It also handles creating nested directories if needed. [[1]](diffhunk://#diff-3222264fc9fd3e6a4097a91255b2063e48ed7f350824b05704afa7c83fc939c9L1-R14) [[2]](diffhunk://#diff-3222264fc9fd3e6a4097a91255b2063e48ed7f350824b05704afa7c83fc939c9R25-R85) [[3]](diffhunk://#diff-3222264fc9fd3e6a4097a91255b2063e48ed7f350824b05704afa7c83fc939c9L98-R175)

**Test Coverage:**

* Added comprehensive tests to verify that results are exported correctly to JSON, including support for relative and nested paths, correct file creation, and validation of result structure and scoring details.

**Internal Refactoring:**

* Updated the signature of `runVitest` and related calls to accept and pass through the new `outputPath` parameter, ensuring the export functionality is triggered appropriately. [[1]](diffhunk://#diff-3222264fc9fd3e6a4097a91255b2063e48ed7f350824b05704afa7c83fc939c9L31-R94) [[2]](diffhunk://#diff-3222264fc9fd3e6a4097a91255b2063e48ed7f350824b05704afa7c83fc939c9L88-R151)

These changes collectively provide a robust mechanism for users to export and consume Evalite test results programmatically.