### PR TITLE
feat: make scorers optional in evalite

### DIFF
--- a/packages/evalite/src/evalite.ts
+++ b/packages/evalite/src/evalite.ts
@@ -75,7 +75,7 @@ const runTask = async <TInput, TOutput, TExpected, TVariant = undefined>(
     })) || [];
 
   const scores = await Promise.all(
-    opts.scorers.map(async (scorerOrOpts) => {
+    (opts.scorers || []).map(async (scorerOrOpts) => {
       if (typeof scorerOrOpts === "function") {
         return scorerOrOpts({
           input: opts.input,

--- a/packages/evalite/src/types.ts
+++ b/packages/evalite/src/types.ts
@@ -106,7 +106,7 @@ export declare namespace Evalite {
   export type RunnerOpts<TInput, TOutput, TExpected, TVariant = undefined> = {
     data: () => MaybePromise<{ input: TInput; expected?: TExpected }[]>;
     task: Task<TInput, TOutput, TVariant>;
-    scorers: Array<
+    scorers?: Array<
       | Scorer<TInput, TOutput, TExpected>
       | ScorerOpts<TInput, TOutput, TExpected>
     >;

--- a/packages/example/src/no-scorers.eval.ts
+++ b/packages/example/src/no-scorers.eval.ts
@@ -1,0 +1,20 @@
+import { evalite } from "evalite";
+
+evalite("No Scorers Example", {
+  data: () => {
+    return [
+      {
+        input: "Hello",
+        expected: "Hello, World!",
+      },
+      {
+        input: "Goodbye",
+        expected: "Goodbye, World!",
+      },
+    ];
+  },
+  task: async (input) => {
+    return `${input}, World!`;
+  },
+  // No scorers field - just collecting outputs for manual review
+});


### PR DESCRIPTION
Allow running evals without scorers for cases where users just want to collect/review outputs without automated scoring.

## Changes
- Made scorers field optional in Evalite.RunnerOpts type
- Updated runTask to handle undefined scorers with empty array fallback
- Added example eval file demonstrating usage without scorers

Fixes #175

Generated with [Claude Code](https://claude.ai/code)