### PR TITLE
fix: prevent error message overflow in trace view

### DIFF
--- a/apps/evalite-ui/app/components/display-input.tsx
+++ b/apps/evalite-ui/app/components/display-input.tsx
@@ -225,7 +225,9 @@ const DisplayError = ({
   return (
     <div className="flex items-start gap-2 text-red-500 dark:text-red-400">
       <AlertCircle className="size-5 flex-shrink-0 mt-0.5" />
-      <div className="whitespace-pre-wrap w-full pr-4">{error.message}</div>
+      <div className="whitespace-pre-wrap w-full pr-4 break-words">
+        {error.message}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

This PR fixes issue #186 where long error messages overflow their width in the trace view.

## Changes

Added `break-words` Tailwind CSS class to the error message container in the `DisplayError` component. This applies `overflow-wrap: break-word` to ensure long error messages wrap properly within the trace view instead of overflowing.

## Testing

To test:
1. Create an eval that generates an error with a long message
2. View the trace in the UI
3. Verify the error message wraps properly without horizontal overflow

Closes #186

---

Generated with [Claude Code](https://claude.ai/code)