### PR TITLE
feat: add syntax highlighting with Shiki

### DIFF
--- a/apps/evalite-ui/app/components/display-input.tsx
+++ b/apps/evalite-ui/app/components/display-input.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, ChevronDown, DownloadIcon } from "lucide-react";
 import React, { Fragment, useLayoutEffect, useRef, useState } from "react";
 import { JSONTree } from "react-json-tree";
 import ReactMarkdown from "react-markdown";
+import rehypePrettyCode from "rehype-pretty-code";
 import remarkGfm from "remark-gfm";
 import { downloadFile, serveFile } from "~/sdk";
 import { Button } from "./ui/button";
@@ -82,6 +83,15 @@ const DisplayText = ({
           <ReactMarkdown
             className="prose dark:prose-invert prose-sm"
             remarkPlugins={[remarkGfm]}
+            rehypePlugins={[
+              [
+                rehypePrettyCode,
+                {
+                  theme: "github-dark",
+                  keepBackground: false,
+                },
+              ],
+            ]}
           >
             {input}
           </ReactMarkdown>

--- a/apps/evalite-ui/package.json
+++ b/apps/evalite-ui/package.json
@@ -36,6 +36,9 @@
     "react-json-tree": "^0.19.0",
     "react-markdown": "^9.0.1",
     "recharts": "^2.14.1",
+    "rehype-pretty-code": "^0.15.1",
+    "remark-gfm": "^4.0.0",
+    "shiki": "^1.24.6",
     "tailwind-merge": "^3.3.1",
     "zod": "^3.23.8"
   },


### PR DESCRIPTION
Implements syntax highlighting for code blocks in the Evalite UI using Shiki.

## Changes
- Add shiki, rehype-pretty-code, and remark-gfm dependencies
- Configure rehype-pretty-code plugin in DisplayInput component
- Use github-dark theme to match existing UI
- Set keepBackground: false for better integration

Closes #97

Generated with [Claude Code](https://claude.ai/code)