### PR TITLE
fix: remove duplicate columns in trace view when custom columns present

### DIFF
--- a/apps/evalite-ui/app/routes/eval.$name.result.$resultIndex.tsx
+++ b/apps/evalite-ui/app/routes/eval.$name.result.$resultIndex.tsx
@@ -347,13 +347,6 @@ function ResultComponent() {
                     ) : null}
                   </Fragment>
                 ))}
-
-                {hasCustomColumns && (
-                  <>
-                    <MainBodySeparator />
-                    {inputOutputSection}
-                  </>
-                )}
               </>
             )}
             {traceBeingViewed && (


### PR DESCRIPTION
Fixes #71

When custom columns are defined in `experimental_customColumns` or `columns`, the trace view was showing duplicate sections:
1. The custom columns (which may include output/expected)
2. The default input/output/expected sections again at the bottom

This PR removes the duplicate default sections (lines 351-356) so only the custom columns are displayed, eliminating the duplication issue.

### Changes
- Removed lines 351-356 from `apps/evalite-ui/app/routes/eval.$name.result.$resultIndex.tsx`

### Behavior
**With custom columns:**
- Only custom columns are displayed
- No duplication

**Without custom columns:**
- Default input/output/expected sections display normally

Generated with [Claude Code](https://claude.ai/code)