### PR TITLE
Increase timeout and limit wokers for evalite-tests

### DIFF
--- a/packages/evalite-tests/vitest.config.ts
+++ b/packages/evalite-tests/vitest.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     maxConcurrency: process.env.CI ? 1 : 5,
+    maxWorkers: "50%",
+    testTimeout: 10000,
   },
 });


### PR DESCRIPTION
`pnpm --filter evalite-tests dev` was freezing up my computer and most of the tests were timing out, I experimented with a variation of configs for the vitest.config.ts and this is what I landed on as the best compromise. I'm guessing since each test spins up another vitest there could be a better solution here... perhaps if the fixture had its own evalite.config.ts that limited workers/concurrency? I'm not sure

If I just limited maxWorkers to something like `2`, the timeouts would go away. However, `maxWorkers: 50%` didn't get the timeouts to go away altogether; there were still a handful, so I bumped the max timeout as well.

Computer is a Macbook M3 Max (14 cores) with 36 GB memory