### PR TITLE
Fix error logging in watch mode

### DIFF
--- a/.changeset/0000-fix-error-logging.md
+++ b/.changeset/0000-fix-error-logging.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Fix error logging in watch mode by restoring error details display.

--- a/packages/evalite/src/reporter.ts
+++ b/packages/evalite/src/reporter.ts
@@ -11,6 +11,7 @@ import { BasicReporter } from "vitest/reporters";
 import { EvaliteRunner } from "./reporter/EvaliteRunner.js";
 import {
   renderDetailedTable,
+  renderErrorsSummary,
   renderInitMessage,
   renderScoreDisplay,
   renderServeModeFinalMessage,
@@ -69,12 +70,12 @@ export default class EvaliteReporter extends BasicReporter implements Reporter {
     files: RunnerTestFile[] = [],
     errors: unknown[] = []
   ): void {
-    const hasErrors = (errors?.length ?? 0) > 0 || hasFailed(files);
     const failedDueToThreshold =
       this.runner.getDidLastRunFailThreshold() === "yes";
 
     renderWatcherStart(this.ctx.logger, {
-      hasErrors,
+      files,
+      errors,
       failedDueToThreshold,
       scoreThreshold: this.opts.scoreThreshold,
     });
@@ -99,7 +100,10 @@ export default class EvaliteReporter extends BasicReporter implements Reporter {
     // Wait for all queued events to complete
     await this.runner.waitForCompletion();
 
-    // Call reportTestSummary manually since BasicReporter's onFinished doesn't
+    // Print errors first (mimicking DefaultReporter's reportSummary -> printErrorsSummary flow)
+    renderErrorsSummary(this.ctx.logger, { files, errors });
+
+    // Then print test summary
     this.reportTestSummary(files);
   };
 


### PR DESCRIPTION
## Summary
Fixes #239 - restores error details display that was lost during the BasicReporter migration.

## Changes
- Updated `renderWatcherStart()` to use Vitest's `printError()` and `printUnhandledErrors()` methods
- Added `renderErrorsSummary()` function for displaying errors in non-watch mode
- Modified `onFinished()` to call `renderErrorsSummary()` before test summary

## Approach
Instead of reimplementing error display logic, leverages Vitest's built-in error logging methods for:
- Consistent error formatting with standard Vitest
- Automatic stack trace parsing/source mapping
- Code frames and proper colorization
- Less code to maintain

## Testing
- All 68 existing tests pass
- Manually verified error display in both watch mode and run-once mode
- Errors now show full stack traces, code frames, and file locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)