### PR TITLE
Track eval duration accurately via reporter timestamps

### DIFF
--- a/packages/evalite/src/db.ts
+++ b/packages/evalite/src/db.ts
@@ -625,19 +625,28 @@ export const updateEvalStatusAndDuration = ({
   db,
   evalId,
   status,
+  duration,
 }: {
   db: SQLiteDatabase;
   evalId: number | bigint;
   status: Db.EvalStatus;
+  duration?: number;
 }) => {
+  const normalizedDuration =
+    typeof duration === "number" ? Math.max(0, Math.round(duration)) : undefined;
+
   db.prepare(
     `UPDATE evals
      SET status = @status,
-     duration = (SELECT MAX(duration) FROM results WHERE eval_id = @id)
+     duration = COALESCE(
+       @duration,
+       (SELECT MAX(duration) FROM results WHERE eval_id = @id)
+     )
      WHERE id = @id`
   ).run({
     id: evalId,
     status,
+    duration: normalizedDuration ?? null,
   });
 };
 

--- a/packages/evalite/src/reporter.ts
+++ b/packages/evalite/src/reporter.ts
@@ -24,6 +24,7 @@ import {
 import type { Evalite } from "./types.js";
 import { average, max } from "./utils.js";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { deserializeAnnotation } from "./reporter/events.js";
 
 export interface EvaliteReporterOptions {
@@ -174,11 +175,13 @@ export default class EvaliteReporter
       this.runner.sendEvent({
         type: "RESULT_STARTED",
         initialResult: data.initialResult,
+        emittedAt: data.emittedAt,
       });
     } else if (data.type === "RESULT_SUBMITTED") {
       this.runner.sendEvent({
         type: "RESULT_SUBMITTED",
         result: data.result,
+        emittedAt: data.emittedAt,
       });
     }
   }
@@ -230,6 +233,7 @@ export default class EvaliteReporter
     if (data && data.type === "RESULT_STARTED") {
       this.runner.sendEvent({
         type: "RESULT_SUBMITTED",
+        emittedAt: performance.now(),
         result: {
           evalName: data.initialResult.evalName,
           filepath: data.initialResult.filepath,

--- a/packages/evalite/src/reporter/events.ts
+++ b/packages/evalite/src/reporter/events.ts
@@ -12,10 +12,12 @@ export type ReporterEvent =
   | {
       type: "RESULT_SUBMITTED";
       result: Evalite.Result;
+      emittedAt?: number;
     }
   | {
       type: "RESULT_STARTED";
       initialResult: Evalite.InitialResult;
+      emittedAt?: number;
     };
 
 /**
@@ -25,10 +27,12 @@ export type EvaliteAnnotation =
   | {
       type: "RESULT_STARTED";
       initialResult: Evalite.InitialResult;
+      emittedAt?: number;
     }
   | {
       type: "RESULT_SUBMITTED";
       result: Evalite.Result;
+      emittedAt?: number;
     };
 
 /**
@@ -55,6 +59,14 @@ export function deserializeAnnotation(
       "type" in data &&
       typeof data.type === "string"
     ) {
+      if (
+        "emittedAt" in data &&
+        data.emittedAt !== undefined &&
+        typeof data.emittedAt !== "number"
+      ) {
+        return null;
+      }
+
       return data as EvaliteAnnotation;
     }
 

--- a/packages/evalite/src/types.ts
+++ b/packages/evalite/src/types.ts
@@ -149,6 +149,16 @@ export declare namespace Evalite {
     path: string;
   };
 
+  export namespace Adapter {
+    export namespace Evals {
+      export interface UpdateOpts {
+        id: number;
+        status: Db.EvalStatus;
+        duration?: number;
+      }
+    }
+  }
+
   export namespace SDK {
     export type GetEvalByNameResult = {
       history: {


### PR DESCRIPTION
### Summary
Fix eval-level duration not being tracked by measuring wall-clock time between first result start and final result submission, and persisting it on the eval.

### Context
- Resolves: [#223 – Eval duration not being tracked properly](https://github.com/mattpocock/evalite/issues/223)
- Previously, `evals.duration` was often 0 or derived indirectly. This adds explicit, accurate timing.

### Changes
- Reporter annotations
  - Add `emittedAt` to `RESULT_STARTED` and `RESULT_SUBMITTED`.
- Runner timing
  - Track per-eval start time on first `RESULT_STARTED`.
  - Compute eval duration on completion using `completionTimestamp - startTime`.
  - Write duration via the DB layer.
- DB updates
  - `updateEvalStatusAndDuration(db, evalId, status, duration?)` now accepts an optional `duration`.
  - Uses `COALESCE(@duration, (SELECT MAX(duration) FROM results ...))` to gracefully fall back if needed.
- Types
  - Extend `Evalite.Adapter.Evals.UpdateOpts` to include optional `duration`.

### Rationale
- Users need a clear eval-level duration that reflects real wall-clock time, not just a max or sum of per-result durations.
- Keeps the old behavior as a fallback if timestamps are unavailable.

### Implementation Details
- Start time set from `RESULT_STARTED.emittedAt` (fallback `performance.now()`).
- Completion time taken from `RESULT_SUBMITTED.emittedAt` (fallback `performance.now()`).
- Duration normalized to a non-negative integer (`Math.max(0, Math.round(...))`).
- Start/completion state cleared per eval to avoid leaks across runs.

### Backward Compatibility
- Safe: If `duration` isn’t provided, DB falls back to previous behavior.
- Event schema changes are additive (`emittedAt?`), preserving existing consumers.


### Checklist
- [x] Duration tracked from reporter timestamps
- [x] DB update supports explicit duration
- [x] Types extended
- [x] Fallbacks in place
- [x] References issue [#223](https://github.com/mattpocock/evalite/issues/223)