### PR TITLE
Update quickstart.mdx to install vitest 3.2.4

### DIFF
--- a/apps/evalite-docs/src/content/docs/quickstart.mdx
+++ b/apps/evalite-docs/src/content/docs/quickstart.mdx
@@ -12,7 +12,7 @@ We're going to walk through setting up Evalite in an existing project.
 1. Install `evalite`, `vitest`, and a scoring library like `autoevals`:
 
    ```bash
-   pnpm add -D evalite vitest autoevals
+   pnpm add -D evalite vitest@^3.2.4 autoevals
    ```
 
 2. Add an `eval:dev` script to your package.json:


### PR DESCRIPTION
These instructions are failing now that vitest 4 is released