### PR TITLE
Make Scorers factories take generic options

### DIFF
--- a/packages/evalite/src/scorers/base.ts
+++ b/packages/evalite/src/scorers/base.ts
@@ -3,10 +3,9 @@ import type { Evalite } from "../types.js";
 
 export function createLLMScorer<
   TExpected extends object,
-  TConfig extends
-    Evalite.Scorers.LLMBasedScorerBaseConfig = Evalite.Scorers.LLMBasedScorerBaseConfig,
->(opts: Evalite.Scorers.LLMBasedScorerFactoryOpts<TExpected>) {
-  return function (config: TConfig) {
+  TConfig extends {} = {},
+>(opts: Evalite.Scorers.LLMBasedScorerFactoryOpts<TExpected, TConfig>) {
+  return function (config: TConfig & Evalite.Scorers.LLMBasedScorerBaseConfig) {
     return createScorer<
       string,
       Evalite.Scorers.SingleOrMultiTurnOutput,
@@ -14,17 +13,18 @@ export function createLLMScorer<
     >({
       name: opts.name,
       description: opts.description,
-      scorer: (input) => opts.scorer({ ...input, model: config.model }),
+      scorer: (input) => opts.scorer({ ...input, ...config }),
     });
   };
 }
 
 export function createEmbeddingScorer<
   TExpected extends object,
-  TConfig extends
-    Evalite.Scorers.EmbeddingBasedScorerBaseConfig = Evalite.Scorers.EmbeddingBasedScorerBaseConfig,
->(opts: Evalite.Scorers.EmbeddingBasedScorerFactoryOpts<TExpected>) {
-  return function (config: TConfig) {
+  TConfig extends {} = {},
+>(opts: Evalite.Scorers.EmbeddingBasedScorerFactoryOpts<TExpected, TConfig>) {
+  return function (
+    config: TConfig & Evalite.Scorers.EmbeddingBasedScorerBaseConfig
+  ) {
     return createScorer<
       string,
       Evalite.Scorers.SingleOrMultiTurnOutput,
@@ -32,8 +32,7 @@ export function createEmbeddingScorer<
     >({
       name: opts.name,
       description: opts.description,
-      scorer: (input) =>
-        opts.scorer({ ...input, embeddingModel: config.embeddingModel }),
+      scorer: (input) => opts.scorer({ ...input, ...config }),
     });
   };
 }

--- a/packages/evalite/src/types.ts
+++ b/packages/evalite/src/types.ts
@@ -784,11 +784,16 @@ export declare namespace Evalite {
       ) => Evalite.MaybePromise<Evalite.UserProvidedScoreWithMetadata>;
     }
 
-    export interface LLMBasedScorerFactoryOpts<TExpected extends object> {
+    export interface LLMBasedScorerFactoryOpts<
+      TExpected extends object,
+      TConfig extends object = {},
+    > {
       name: string;
       description?: string;
       scorer: (
-        input: LLMBasedScorerOpts<TExpected>
+        input: LLMBasedScorerOpts<TExpected> &
+          TConfig &
+          Evalite.Scorers.LLMBasedScorerBaseConfig
       ) => Evalite.MaybePromise<Evalite.UserProvidedScoreWithMetadata>;
     }
 
@@ -800,11 +805,16 @@ export declare namespace Evalite {
       extends Evalite.ScoreInput<string, SingleOrMultiTurnOutput, TExpected>,
         LLMBasedScorerBaseConfig {}
 
-    export interface EmbeddingBasedScorerFactoryOpts<TExpected extends object> {
+    export interface EmbeddingBasedScorerFactoryOpts<
+      TExpected extends object,
+      TConfig extends object = {},
+    > {
       name: string;
       description?: string;
       scorer: (
-        input: EmbeddingBasedScorerOpts<TExpected>
+        input: EmbeddingBasedScorerOpts<TExpected> &
+          TConfig &
+          Evalite.Scorers.EmbeddingBasedScorerBaseConfig
       ) => Evalite.MaybePromise<Evalite.UserProvidedScoreWithMetadata>;
     }
 


### PR DESCRIPTION
The factories initially supported generic config but was never making use of it properly fixed it.