### PR TITLE
Use window.location.origin for WebSocket and BASE_URL to allow opening evalite running on remote server

### DIFF
--- a/.changeset/tasty-parents-bathe.md
+++ b/.changeset/tasty-parents-bathe.md
@@ -1,0 +1,5 @@
+---
+"evalite-ui": patch
+---
+
+Use window.location.origin for WebSocket and BASE_URL to allow opening evalite running on remote server

--- a/apps/evalite-ui/app/data/use-subscribe-to-socket.ts
+++ b/apps/evalite-ui/app/data/use-subscribe-to-socket.ts
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import type { QueryClient } from "@tanstack/react-query";
 import { getServerStateQueryOptions } from "./queries";
 import type { Evalite } from "evalite/types";
-import { DEFAULT_SERVER_PORT } from "evalite/constants";
 import { isStaticMode } from "~/sdk";
 
 export const useSubscribeToSocket = (queryClient: QueryClient) => {
@@ -13,7 +12,7 @@ export const useSubscribeToSocket = (queryClient: QueryClient) => {
     }
 
     const socket = new WebSocket(
-      `ws://localhost:${DEFAULT_SERVER_PORT}/api/socket`
+      `${window.location.origin}/api/socket`
     );
 
     socket.onmessage = async (event) => {

--- a/apps/evalite-ui/app/sdk.ts
+++ b/apps/evalite-ui/app/sdk.ts
@@ -1,8 +1,7 @@
 import { notFound } from "@tanstack/react-router";
-import { DEFAULT_SERVER_PORT } from "evalite/constants";
 import type { Evalite } from "evalite/types";
 
-const BASE_URL = `http://localhost:${DEFAULT_SERVER_PORT}`;
+const BASE_URL = window.location.origin;
 
 declare global {
   interface Window {


### PR DESCRIPTION
Use window.location.origin to build the evalite-ui's WebSocket URL, and BASE_URL to enable connecting to an Evalite instance hosted on a remote server as well as on localhost.