### PR TITLE
fix: show truncated filename in file download button

### DIFF
--- a/apps/evalite-ui/app/components/display-input.tsx
+++ b/apps/evalite-ui/app/components/display-input.tsx
@@ -183,8 +183,42 @@ const DisplayJSON = ({
   );
 };
 
+// Helper function to truncate filename with ellipsis in the middle
+const truncateFilename = (filename: string, maxLength: number = 20): string => {
+  // If filename is short enough, return it as is
+  if (filename.length <= maxLength) {
+    return filename;
+  }
+
+  // Split filename into basename and extension
+  const lastDotIndex = filename.lastIndexOf(".");
+  const extension = lastDotIndex !== -1 ? filename.slice(lastDotIndex + 1) : "";
+  const basename = lastDotIndex !== -1 ? filename.slice(0, lastDotIndex) : filename;
+
+  // If there's no extension or it's very short, truncate the whole filename
+  if (!extension || extension.length > 10) {
+    const keepLength = Math.floor((maxLength - 3) / 2);
+    return `${filename.slice(0, keepLength)}...${filename.slice(-keepLength)}`;
+  }
+
+  // Calculate how much space we have for the basename (accounting for extension and dot)
+  const availableLength = maxLength - extension.length - 4; // -4 for "..." and "."
+
+  // If basename is too short to truncate meaningfully, just truncate at the end
+  if (availableLength < 6) {
+    return `${basename.slice(0, maxLength - extension.length - 4)}...${extension}`;
+  }
+
+  // Split available space: 60% to start, 40% to end of basename
+  const keepStart = Math.floor(availableLength * 0.6);
+  const keepEnd = Math.floor(availableLength * 0.4);
+
+  return `${basename.slice(0, keepStart)}...${basename.slice(-keepEnd)}.${extension}`;
+};
+
 export const DisplayEvaliteFile = ({ file }: { file: Evalite.File }) => {
   const extension = file.path.split(".").pop()!;
+  const filename = file.path.split("/").pop()!;
 
   // Images
   if (["png", "jpg", "jpeg", "gif", "svg", "webp"].includes(extension)) {
@@ -212,10 +246,10 @@ export const DisplayEvaliteFile = ({ file }: { file: Evalite.File }) => {
   }
 
   return (
-    <Button asChild className="uppercase" variant={"secondary"} size={"sm"}>
-      <a href={downloadFile(file.path)}>
+    <Button asChild variant={"secondary"} size={"sm"}>
+      <a href={downloadFile(file.path)} title={filename}>
         <DownloadIcon className="size-4" />
-        <span>.{extension}</span>
+        <span>{truncateFilename(filename)}</span>
       </a>
     </Button>
   );


### PR DESCRIPTION
Previously, the file download button only displayed the extension (e.g., ".xlsx"), making it impossible to distinguish between multiple files of the same type. This PR implements filename truncation with middle ellipsis to show meaningful context while preventing long filenames from dominating the UI.

## Changes
- Added truncateFilename() helper that intelligently truncates long filenames
- Preserves both the start and extension with 60/40 split
- Displays full filename for short names (≤20 chars)
- Added native browser tooltip showing full filename on hover
- Removed uppercase styling on filenames

Fixes #327

Generated with [Claude Code](https://claude.ai/code)