### PR TITLE
Add per eval score threshold support to Evalite

### DIFF
--- a/.changeset/0000-per-eval-threshold.md
+++ b/.changeset/0000-per-eval-threshold.md
@@ -1,0 +1,5 @@
+---
+"evalite": minor
+---
+
+Added per-eval `scoreThreshold` option that overrides the global threshold (from config or `--threshold` CLI flag). This allows different evals to have different quality requirements.

--- a/packages/evalite/src/evalite.ts
+++ b/packages/evalite/src/evalite.ts
@@ -236,6 +236,12 @@ function registerEvalite<TInput, TOutput, TExpected>(
     : evalName;
 
   return describeFn(fullEvalName, async () => {
+    const configTrialCount = inject("trialCount");
+    const trialCount = opts.trialCount ?? configTrialCount ?? 1;
+
+    const configScoreThreshold = inject("scoreThreshold");
+    const scoreThreshold = opts.scoreThreshold ?? configScoreThreshold;
+
     const datasetResult = await datasetPromise;
 
     if (!datasetResult.success) {
@@ -251,6 +257,7 @@ function registerEvalite<TInput, TOutput, TExpected>(
               variantName: vitestOpts.variantName,
               variantGroup: vitestOpts.variantGroup,
               trialIndex: undefined,
+              scoreThreshold: scoreThreshold,
               duration: 0,
               expected: null,
               input: null,
@@ -275,10 +282,6 @@ function registerEvalite<TInput, TOutput, TExpected>(
     const filteredDataset = hasOnlyFlag
       ? dataset.filter((d) => d.only === true)
       : dataset;
-
-    // Get trialCount from opts or config (opts wins)
-    const configTrialCount = inject("trialCount");
-    const trialCount = opts.trialCount ?? configTrialCount ?? 1;
 
     // Expand dataset with trials
     const expandedDataset: Array<{
@@ -329,6 +332,7 @@ function registerEvalite<TInput, TOutput, TExpected>(
               variantGroup: vitestOpts.variantGroup,
               status: "running",
               trialIndex: data.trialIndex,
+              scoreThreshold: scoreThreshold,
             },
           })
         );
@@ -433,6 +437,7 @@ function registerEvalite<TInput, TOutput, TExpected>(
                 variantName: vitestOpts.variantName,
                 variantGroup: vitestOpts.variantGroup,
                 trialIndex: data.trialIndex,
+                scoreThreshold: scoreThreshold,
               },
             })
           );
@@ -469,6 +474,7 @@ function registerEvalite<TInput, TOutput, TExpected>(
                 variantName: vitestOpts.variantName,
                 variantGroup: vitestOpts.variantGroup,
                 trialIndex: data.trialIndex,
+                scoreThreshold: scoreThreshold,
               },
             })
           );

--- a/packages/evalite/src/reporter.ts
+++ b/packages/evalite/src/reporter.ts
@@ -81,6 +81,7 @@ export default class EvaliteReporter implements Reporter {
       errors,
       failedDueToThreshold,
       scoreThreshold: this.opts.scoreThreshold,
+      failedThresholds: this.runner.getFailedThresholds(),
     });
   }
 
@@ -371,6 +372,7 @@ export default class EvaliteReporter implements Reporter {
           variantName: data.initialEval.variantName,
           variantGroup: data.initialEval.variantGroup,
           trialIndex: data.initialEval.trialIndex,
+          scoreThreshold: data.initialEval.scoreThreshold,
         },
       });
     }

--- a/packages/evalite/src/reporter/rendering.ts
+++ b/packages/evalite/src/reporter/rendering.ts
@@ -6,6 +6,7 @@ import type { RunnerTestFile } from "vitest";
 import type { Evalite } from "../types.js";
 import { average, EvaliteFile } from "../utils.js";
 import type { TestModule } from "vitest/node";
+import type { FailedThresholdInfo } from "./EvaliteRunner.js";
 
 export function withLabel(
   color: "red" | "green" | "blue" | "cyan",
@@ -54,6 +55,7 @@ export function renderWatcherStart(
     errors: unknown[];
     failedDueToThreshold: boolean;
     scoreThreshold: number | undefined;
+    failedThresholds: FailedThresholdInfo[];
   }
 ) {
   logger.log("");
@@ -91,9 +93,26 @@ export function renderWatcherStart(
       withLabel(
         "red",
         "FAIL",
-        `${opts.scoreThreshold}% threshold not met. Watching for file changes...`
+        "Score threshold not met. Watching for file changes..."
       )
     );
+
+    if (opts.failedThresholds.length > 0) {
+      for (const failed of opts.failedThresholds) {
+        const scoreDisplay =
+          failed.score === null
+            ? c.red("no score")
+            : c.red(`${Math.round(failed.score * 100)}%`);
+        logger.log(
+          BADGE_PADDING +
+            c.dim("- ") +
+            failed.suiteName +
+            c.dim(": ") +
+            scoreDisplay +
+            c.dim(` < ${failed.threshold}%`)
+        );
+      }
+    }
   } else {
     logger.log(withLabel("green", "PASS", "Waiting for file changes..."));
   }

--- a/packages/evalite/src/run-evalite.ts
+++ b/packages/evalite/src/run-evalite.ts
@@ -23,6 +23,11 @@ declare module "vitest" {
      */
     trialCount: number | undefined;
     /**
+     * Global score threshold (0-100).
+     * Per-eval thresholds override this when set.
+     */
+    scoreThreshold: number | undefined;
+    /**
      * Port number where the evalite server is running.
      * Used by cache and other features that need to communicate with the server.
      */
@@ -349,6 +354,7 @@ export const runEvalite = async (opts: {
 
   vitest.provide("cwd", cwd);
   vitest.provide("trialCount", config?.trialCount);
+  vitest.provide("scoreThreshold", scoreThreshold);
   vitest.provide("serverPort", actualServerPort);
   vitest.provide("cacheDebug", opts.cacheDebug ?? false);
   vitest.provide("cacheEnabled", cacheEnabled);

--- a/packages/evalite/src/types.ts
+++ b/packages/evalite/src/types.ts
@@ -188,6 +188,7 @@ export declare namespace Evalite {
     variantName: string | undefined;
     variantGroup: string | undefined;
     trialIndex: number | undefined;
+    scoreThreshold: number | undefined;
   }
 
   export type EvalStatus = "success" | "fail" | "running";
@@ -211,6 +212,7 @@ export declare namespace Evalite {
     variantName: string | undefined;
     variantGroup: string | undefined;
     trialIndex: number | undefined;
+    scoreThreshold: number | undefined;
     /**
      * Technically, input and expected are known at the start
      * of the suite. But because they may be files, they
@@ -313,6 +315,20 @@ export declare namespace Evalite {
      * ```
      */
     trialCount?: number;
+    /**
+     * Minimum average score threshold (0-100) for this eval.
+     * If the average score falls below this threshold, the process will exit with code 1.
+     * Overrides the global scoreThreshold when set.
+     * @example
+     * ```ts
+     * evalite("My Eval", {
+     *   data: [...],
+     *   task: ...,
+     *   scoreThreshold: 80 // This eval requires 80%
+     * })
+     * ```
+     */
+    scoreThreshold?: number;
   };
 
   export type ScorerOpts<TInput, TOutput, TExpected> = {


### PR DESCRIPTION
## Per-eval `scoreThreshold` override

Adds the ability to set `scoreThreshold` per-eval, overriding the global threshold when specified.

### Usage

```ts
evalite("Eval that requires high percision", {
  data: [...],
  task: ...,
  scoreThreshold: 95, // Requires 95%
});

evalite("Baseline Eval", {
  data: [...],
  task: ...,
  scoreThreshold: 80, // Only requires 80%
});
```

### Behavior

- Per-eval threshold overrides global when set
- Falls back to global threshold when not specified
- If ANY eval fails its threshold, exit code is 1

### Watch mode output

When thresholds fail, shows which evals failed:

```
 FAIL  Score threshold not met. Watching for file changes...
       - High-Quality Eval: 75% < 95%
       - Baseline Eval: 60% < 80%
```

Solves: #347