### PR TITLE
feat: add Postgres storage adapter

### DIFF
--- a/.changeset/postgres-storage-adapter.md
+++ b/.changeset/postgres-storage-adapter.md
@@ -1,0 +1,5 @@
+---
+"evalite": minor
+---
+
+Add Postgres storage adapter (`evalite/postgres-storage`) for persisting eval results to PostgreSQL databases. Includes optional `postgres` peer dependency, configurable schema/table names, and conditional test coverage via `EVALITE_TEST_POSTGRES_URL`.

--- a/apps/evalite-docs/astro.config.mts
+++ b/apps/evalite-docs/astro.config.mts
@@ -131,6 +131,10 @@ export default defineConfig({
               slug: "guides/configuration",
             },
             {
+              label: "Storage",
+              slug: "guides/storage",
+            },
+            {
               label: "Streams",
               slug: "guides/streams",
             },

--- a/apps/evalite-docs/src/content/docs/guides/configuration.mdx
+++ b/apps/evalite-docs/src/content/docs/guides/configuration.mdx
@@ -34,6 +34,7 @@ export default defineConfig({
 - **`server.port`**: Port for the Evalite UI server. Default is 3006.
 - **`trialCount`**: Number of times to run each test case. Default is 1. Useful for measuring variance in non-deterministic evaluations.
 - **`setupFiles`**: Array of file paths to run before tests (e.g., for loading environment variables).
+- **`storage`**: Factory function returning a storage adapter. Defaults to local SQLite. See the [Storage guide](/guides/storage/) for Postgres and other options.
 
 ## Important Configuration Options
 

--- a/apps/evalite-docs/src/content/docs/guides/storage.mdx
+++ b/apps/evalite-docs/src/content/docs/guides/storage.mdx
@@ -1,0 +1,174 @@
+---
+title: Storage
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+By default, Evalite persists results to a local SQLite database at `.evalite/cache.sqlite`. This works well for individual development, but you may want to use a different storage backend for team-wide visibility or CI/CD persistence.
+
+## Available Adapters
+
+Evalite ships with three storage adapters:
+
+- **SQLite** (default) — local file-based storage, zero configuration
+- **InMemory** — ephemeral storage for testing, results are discarded on exit
+- **Postgres** — persist results to a PostgreSQL database for shared, durable storage
+
+## Postgres Storage
+
+Use Postgres storage when you want eval results accessible across machines, CI runs, or team members.
+
+<Steps>
+
+1. **Install the `postgres` package**
+
+   Evalite uses [postgres.js](https://github.com/porsager/postgres) as its Postgres client. Install it as a peer dependency:
+
+   ```bash
+   npm install postgres
+   ```
+
+2. **Create the database schema**
+
+   Evalite does not auto-create tables. Run the following DDL against your database to set up the required schema:
+
+   ```sql
+   CREATE SCHEMA IF NOT EXISTS evals;
+
+   CREATE TABLE evals.runs (
+       id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+       run_type TEXT NOT NULL CHECK (run_type IN ('full', 'partial')),
+       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+   );
+
+   CREATE TABLE evals.evaluations (
+       id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+       run_id INTEGER NOT NULL REFERENCES evals.runs(id) ON DELETE CASCADE,
+       name TEXT NOT NULL,
+       filepath TEXT NOT NULL,
+       status TEXT NOT NULL DEFAULT 'running'
+           CHECK (status IN ('running', 'success', 'fail')),
+       duration INTEGER NOT NULL DEFAULT 0,
+       variant_name TEXT,
+       variant_group TEXT,
+       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+   );
+
+   CREATE TABLE evals.results (
+       id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+       eval_id INTEGER NOT NULL REFERENCES evals.evaluations(id) ON DELETE CASCADE,
+       duration INTEGER NOT NULL,
+       input JSONB,
+       output JSONB,
+       expected JSONB,
+       col_order INTEGER NOT NULL,
+       status TEXT NOT NULL DEFAULT 'success',
+       rendered_columns JSONB,
+       trial_index INTEGER,
+       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+   );
+
+   CREATE TABLE evals.scores (
+       id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+       result_id INTEGER NOT NULL REFERENCES evals.results(id) ON DELETE CASCADE,
+       name TEXT NOT NULL,
+       score DOUBLE PRECISION NOT NULL,
+       description TEXT,
+       metadata JSONB,
+       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+   );
+
+   CREATE TABLE evals.traces (
+       id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+       result_id INTEGER NOT NULL REFERENCES evals.results(id) ON DELETE CASCADE,
+       input JSONB NOT NULL,
+       output JSONB NOT NULL,
+       start_time BIGINT NOT NULL,
+       end_time BIGINT NOT NULL,
+       input_tokens INTEGER,
+       output_tokens INTEGER,
+       total_tokens INTEGER,
+       col_order INTEGER NOT NULL
+   );
+   ```
+
+   You can customize the schema name and evaluations table name via the adapter options.
+
+3. **Configure `evalite.config.ts`**
+
+   ```ts
+   import { defineConfig } from "evalite/config";
+   import { createPostgresStorage } from "evalite/postgres-storage";
+
+   export default defineConfig({
+     storage: () =>
+       createPostgresStorage(process.env.DATABASE_URL!, {
+         schema: "evals", // default
+       }),
+   });
+   ```
+
+   The `storage` option accepts a factory function that returns a storage instance. This is called once when Evalite starts.
+
+</Steps>
+
+### Options
+
+`createPostgresStorage` accepts either a connection string or an options object with individual connection parameters:
+
+```ts
+// Connection string
+createPostgresStorage("postgresql://user:pass@host:5432/db", opts?)
+
+// Individual parameters
+createPostgresStorage({
+  host: "db.example.com",
+  port: 5432,
+  database: "mydb",
+  user: "postgres",
+  password: "secret",
+  ssl: "require",
+  maxConnections: 10,
+  schema: "evals",
+})
+```
+
+**Connection options:**
+
+- **`host`** — database host (default: `"localhost"`)
+- **`port`** — database port (default: `5432`)
+- **`database`** — database name (default: `"postgres"`)
+- **`user`** — database user (default: `"postgres"`)
+- **`password`** — database password
+- **`ssl`** — enable SSL (`true`, `"require"`, or `"prefer"`)
+- **`maxConnections`** — maximum connections in the pool
+
+**Storage options (available in both forms):**
+
+- **`schema`** — Postgres schema to use (default: `"evals"`)
+- **`evaluationsTable`** — table name for evaluations (default: `"evaluations"`)
+
+### Loading Environment Variables
+
+Since the `storage` factory runs at config load time (before Vitest setup files), you need to load environment variables directly in the config file:
+
+```ts
+import "dotenv/config";
+import { defineConfig } from "evalite/config";
+import { createPostgresStorage } from "evalite/postgres-storage";
+
+export default defineConfig({
+  storage: () =>
+    createPostgresStorage(process.env.DATABASE_URL!, {
+      schema: "evals",
+    }),
+});
+```
+
+> [!IMPORTANT]
+>
+> The `setupFiles` option loads files for Vitest test workers, not the Evalite CLI process. If your connection string comes from a `.env` file, import `dotenv/config` at the top of `evalite.config.ts`.
+
+## Custom Storage
+
+All storage adapters implement the `Evalite.Storage` interface. You can create your own adapter by implementing this interface. See the [source code](https://github.com/mattpocock/evalite/tree/main/packages/evalite/src/storage) for reference implementations.

--- a/packages/evalite/package.json
+++ b/packages/evalite/package.json
@@ -45,7 +45,16 @@
     "./runner": "./dist/run-evalite.js",
     "./export-static": "./dist/export-static.js",
     "./sqlite-storage": "./dist/storage/sqlite.js",
-    "./in-memory-storage": "./dist/storage/in-memory.js"
+    "./in-memory-storage": "./dist/storage/in-memory.js",
+    "./postgres-storage": "./dist/storage/postgres.js"
+  },
+  "peerDependencies": {
+    "postgres": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "postgres": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@ai-sdk/provider": "^2.0.0",

--- a/packages/evalite/src/storage/postgres.ts
+++ b/packages/evalite/src/storage/postgres.ts
@@ -17,6 +17,20 @@ type PostgresStorageOpts = {
   schema?: string;
   /** Table name for evaluations (default: 'evaluations') */
   evaluationsTable?: string;
+  /** Host to connect to (alternative to connection string) */
+  host?: string;
+  /** Port to connect to (default: 5432) */
+  port?: number;
+  /** Database name */
+  database?: string;
+  /** Database user */
+  user?: string;
+  /** Database password */
+  password?: string;
+  /** Enable SSL connection */
+  ssl?: boolean | "require" | "prefer";
+  /** Maximum number of connections in the pool */
+  maxConnections?: number;
 };
 
 export class PostgresStorage implements Evalite.Storage {
@@ -461,11 +475,13 @@ export class PostgresStorage implements Evalite.Storage {
 /**
  * Create a new Postgres storage backend for evalite.
  *
- * @param connectionString - Postgres connection string (e.g. postgresql://user:pass@host:5432/db)
- * @param opts - Optional configuration (schema, table names)
+ * Accepts either a connection string or individual connection parameters via opts.
+ *
+ * @param connectionStringOrOpts - Postgres connection string, or opts object with connection params
+ * @param opts - Optional configuration when using a connection string
  * @returns A new PostgresStorage instance
  *
- * @example
+ * @example Connection string
  * ```ts
  * import { createPostgresStorage } from "evalite/postgres-storage";
  *
@@ -475,16 +491,60 @@ export class PostgresStorage implements Evalite.Storage {
  *   }),
  * });
  * ```
+ *
+ * @example Individual parameters
+ * ```ts
+ * import { createPostgresStorage } from "evalite/postgres-storage";
+ *
+ * export default defineConfig({
+ *   storage: () => createPostgresStorage({
+ *     host: "db.example.com",
+ *     port: 5432,
+ *     database: "mydb",
+ *     user: "postgres",
+ *     password: "secret",
+ *     ssl: "require",
+ *     maxConnections: 10,
+ *     schema: "evals",
+ *   }),
+ * });
+ * ```
  */
 export const createPostgresStorage = async (
-  connectionString: string,
+  connectionStringOrOpts: string | PostgresStorageOpts,
   opts?: PostgresStorageOpts
 ): Promise<PostgresStorage> => {
   const pgModule = await import("postgres");
   const pg = pgModule.default;
-  const schema = opts?.schema ?? "evals";
-  const sql = pg(connectionString, {
+
+  const resolvedOpts =
+    typeof connectionStringOrOpts === "string" ? opts : connectionStringOrOpts;
+  const schema = resolvedOpts?.schema ?? "evals";
+  const pgOpts: Record<string, unknown> = {
     connection: { search_path: `${schema},public` },
-  });
-  return PostgresStorage.create(sql, opts);
+  };
+
+  if (resolvedOpts?.maxConnections) {
+    pgOpts.max = resolvedOpts.maxConnections;
+  }
+  if (resolvedOpts?.ssl !== undefined) {
+    pgOpts.ssl = resolvedOpts.ssl;
+  }
+
+  let sql: Sql;
+  if (typeof connectionStringOrOpts === "string") {
+    sql = pg(connectionStringOrOpts, pgOpts);
+  } else {
+    // Build a connection string from individual params
+    const host = resolvedOpts?.host ?? "localhost";
+    const port = resolvedOpts?.port ?? 5432;
+    const user = resolvedOpts?.user ?? "postgres";
+    const password = resolvedOpts?.password;
+    const database = resolvedOpts?.database ?? "postgres";
+    const auth = password ? `${user}:${password}` : user;
+    const connString = `postgresql://${auth}@${host}:${port}/${database}`;
+    sql = pg(connString, pgOpts);
+  }
+
+  return PostgresStorage.create(sql, resolvedOpts);
 };

--- a/packages/evalite/src/storage/postgres.ts
+++ b/packages/evalite/src/storage/postgres.ts
@@ -1,0 +1,490 @@
+import type { Evalite } from "../types.js";
+import type postgres from "postgres";
+
+type Sql = ReturnType<typeof postgres>;
+
+// postgres.js JSONValue type for sql.json() calls
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | { [key: string]: JSONValue };
+
+type PostgresStorageOpts = {
+  /** Postgres schema to use (default: 'evals') */
+  schema?: string;
+  /** Table name for evaluations (default: 'evaluations') */
+  evaluationsTable?: string;
+};
+
+export class PostgresStorage implements Evalite.Storage {
+  private sql: Sql;
+  private schema: string;
+  private evalsTable: string;
+
+  private constructor(sql: Sql, opts?: PostgresStorageOpts) {
+    this.sql = sql;
+    this.schema = opts?.schema ?? "evals";
+    this.evalsTable = opts?.evaluationsTable ?? "evaluations";
+  }
+
+  static async create(
+    sql: Sql,
+    opts?: PostgresStorageOpts
+  ): Promise<PostgresStorage> {
+    const schema = opts?.schema ?? "evals";
+    await sql.unsafe(`SET search_path TO ${schema}, public`);
+    return new PostgresStorage(sql, opts);
+  }
+
+  private toISOString(val: unknown): string {
+    if (val instanceof Date) return val.toISOString();
+    return String(val);
+  }
+
+  private json(val: unknown): ReturnType<Sql["json"]> | null {
+    if (val === undefined || val === null) return null;
+    return this.sql.json(val as JSONValue);
+  }
+
+  private mapRunRow(
+    row: Record<string, unknown>
+  ): Evalite.Storage.Entities.Run {
+    return {
+      id: Number(row.id),
+      runType: row.run_type as Evalite.RunType,
+      created_at: this.toISOString(row.created_at),
+    };
+  }
+
+  private mapEvalRow(
+    row: Record<string, unknown>
+  ): Evalite.Storage.Entities.Eval {
+    return {
+      id: Number(row.id),
+      run_id: Number(row.run_id),
+      name: row.name as string,
+      filepath: row.filepath as string,
+      status: row.status as Evalite.Storage.Entities.EvalStatus,
+      duration: Number(row.duration),
+      created_at: this.toISOString(row.created_at),
+      variant_name: row.variant_name as string | undefined,
+      variant_group: row.variant_group as string | undefined,
+    };
+  }
+
+  private mapResultRow(
+    row: Record<string, unknown>
+  ): Evalite.Storage.Entities.Result {
+    return {
+      id: Number(row.id),
+      eval_id: Number(row.eval_id),
+      duration: Number(row.duration),
+      input: row.input,
+      output: row.output,
+      expected: row.expected,
+      created_at: this.toISOString(row.created_at),
+      col_order: Number(row.col_order),
+      status: row.status as Evalite.ResultStatus,
+      rendered_columns: row.rendered_columns,
+      trial_index: row.trial_index != null ? Number(row.trial_index) : null,
+    };
+  }
+
+  private mapScoreRow(
+    row: Record<string, unknown>
+  ): Evalite.Storage.Entities.Score {
+    return {
+      id: Number(row.id),
+      result_id: Number(row.result_id),
+      name: row.name as string,
+      score: Number(row.score),
+      description: row.description as string | undefined,
+      metadata: row.metadata,
+      created_at: this.toISOString(row.created_at),
+    };
+  }
+
+  private mapTraceRow(
+    row: Record<string, unknown>
+  ): Evalite.Storage.Entities.Trace {
+    return {
+      id: Number(row.id),
+      result_id: Number(row.result_id),
+      input: row.input,
+      output: row.output,
+      start_time: Number(row.start_time),
+      end_time: Number(row.end_time),
+      input_tokens:
+        row.input_tokens != null ? Number(row.input_tokens) : undefined,
+      output_tokens:
+        row.output_tokens != null ? Number(row.output_tokens) : undefined,
+      total_tokens:
+        row.total_tokens != null ? Number(row.total_tokens) : undefined,
+      col_order: Number(row.col_order),
+    };
+  }
+
+  runs = {
+    create: async (
+      opts: Evalite.Storage.Runs.CreateOpts
+    ): Promise<Evalite.Storage.Entities.Run> => {
+      const [row] = await this.sql`
+        INSERT INTO runs (run_type)
+        VALUES (${opts.runType})
+        RETURNING *
+      `;
+      return this.mapRunRow(row!);
+    },
+
+    getMany: async (
+      opts?: Evalite.Storage.Runs.GetManyOpts
+    ): Promise<Evalite.Storage.Entities.Run[]> => {
+      const conditions: string[] = ["1=1"];
+      const values: (string | number)[] = [];
+      let paramIdx = 0;
+
+      if (opts?.ids && opts.ids.length > 0) {
+        conditions.push(
+          `id IN (${opts.ids.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.ids);
+      }
+
+      if (opts?.runType) {
+        conditions.push(`run_type = $${++paramIdx}`);
+        values.push(opts.runType);
+      }
+
+      if (opts?.createdAt) {
+        conditions.push(`created_at = $${++paramIdx}`);
+        values.push(opts.createdAt);
+      }
+
+      if (opts?.createdAfter) {
+        conditions.push(`created_at > $${++paramIdx}`);
+        values.push(opts.createdAfter);
+      }
+
+      if (opts?.createdBefore) {
+        conditions.push(`created_at < $${++paramIdx}`);
+        values.push(opts.createdBefore);
+      }
+
+      const orderBy = opts?.orderBy ?? "created_at";
+      const orderDir = opts?.orderDirection ?? "DESC";
+      const limitClause = opts?.limit ? `LIMIT ${opts.limit}` : "";
+
+      const rows = await this.sql.unsafe(
+        `SELECT * FROM runs WHERE ${conditions.join(" AND ")} ORDER BY ${orderBy} ${orderDir} ${limitClause}`,
+        values as never[]
+      );
+
+      return rows.map((r) => this.mapRunRow(r));
+    },
+  };
+
+  evals = {
+    create: async (
+      opts: Evalite.Storage.Evals.CreateOpts
+    ): Promise<Evalite.Storage.Entities.Eval> => {
+      const [row] = await this.sql`
+        INSERT INTO ${this.sql(this.evalsTable)} (run_id, name, filepath, duration, status, variant_name, variant_group)
+        VALUES (${opts.runId}, ${opts.name}, ${opts.filepath}, ${0}, ${"running"}, ${opts.variantName ?? null}, ${opts.variantGroup ?? null})
+        RETURNING *
+      `;
+      return this.mapEvalRow(row!);
+    },
+
+    update: async (
+      opts: Evalite.Storage.Evals.UpdateOpts
+    ): Promise<Evalite.Storage.Entities.Eval> => {
+      const [row] = await this.sql`
+        UPDATE ${this.sql(this.evalsTable)}
+        SET status = ${opts.status}
+        WHERE id = ${opts.id}
+        RETURNING *
+      `;
+      return this.mapEvalRow(row!);
+    },
+
+    getMany: async (
+      opts?: Evalite.Storage.Evals.GetManyOpts
+    ): Promise<Evalite.Storage.Entities.Eval[]> => {
+      const table = this.evalsTable;
+      const conditions: string[] = ["1=1"];
+      const values: (string | number)[] = [];
+      let paramIdx = 0;
+
+      if (opts?.ids && opts.ids.length > 0) {
+        conditions.push(
+          `id IN (${opts.ids.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.ids);
+      }
+
+      if (opts?.runIds && opts.runIds.length > 0) {
+        conditions.push(
+          `run_id IN (${opts.runIds.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.runIds);
+      }
+
+      if (opts?.name) {
+        conditions.push(`name = $${++paramIdx}`);
+        values.push(opts.name);
+      }
+
+      if (opts?.statuses && opts.statuses.length > 0) {
+        conditions.push(
+          `status IN (${opts.statuses.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.statuses);
+      }
+
+      if (opts?.createdAt) {
+        conditions.push(`created_at = $${++paramIdx}`);
+        values.push(opts.createdAt);
+      }
+
+      if (opts?.createdAfter) {
+        conditions.push(`created_at > $${++paramIdx}`);
+        values.push(opts.createdAfter);
+      }
+
+      if (opts?.createdBefore) {
+        conditions.push(`created_at < $${++paramIdx}`);
+        values.push(opts.createdBefore);
+      }
+
+      const orderBy = opts?.orderBy ?? "created_at";
+      const orderDir = opts?.orderDirection ?? "DESC";
+      const limitClause = opts?.limit ? `LIMIT ${opts.limit}` : "";
+
+      const rows = await this.sql.unsafe(
+        `SELECT * FROM "${table}" WHERE ${conditions.join(" AND ")} ORDER BY ${orderBy} ${orderDir} ${limitClause}`,
+        values as never[]
+      );
+
+      return rows.map((r) => this.mapEvalRow(r));
+    },
+  };
+
+  results = {
+    create: async (
+      opts: Evalite.Storage.Results.CreateOpts
+    ): Promise<Evalite.Storage.Entities.Result> => {
+      const [row] = await this.sql`
+        INSERT INTO results (eval_id, col_order, input, expected, output, duration, status, rendered_columns, trial_index)
+        VALUES (
+          ${opts.evalId},
+          ${opts.order},
+          ${this.json(opts.input)},
+          ${this.json(opts.expected)},
+          ${this.json(opts.output)},
+          ${opts.duration},
+          ${opts.status},
+          ${this.json(opts.renderedColumns)},
+          ${opts.trialIndex ?? null}
+        )
+        RETURNING *
+      `;
+      return this.mapResultRow(row!);
+    },
+
+    update: async (
+      opts: Evalite.Storage.Results.UpdateOpts
+    ): Promise<Evalite.Storage.Entities.Result> => {
+      const [row] = await this.sql`
+        UPDATE results
+        SET
+          output = ${this.json(opts.output)},
+          duration = ${opts.duration},
+          input = ${this.json(opts.input)},
+          expected = ${this.json(opts.expected)},
+          status = ${opts.status},
+          rendered_columns = ${this.json(opts.renderedColumns)},
+          trial_index = ${opts.trialIndex ?? null}
+        WHERE id = ${opts.id}
+        RETURNING *
+      `;
+      return this.mapResultRow(row!);
+    },
+
+    getMany: async (
+      opts?: Evalite.Storage.Results.GetManyOpts
+    ): Promise<Evalite.Storage.Entities.Result[]> => {
+      const conditions: string[] = ["1=1"];
+      const values: (string | number)[] = [];
+      let paramIdx = 0;
+
+      if (opts?.ids && opts.ids.length > 0) {
+        conditions.push(
+          `id IN (${opts.ids.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.ids);
+      }
+
+      if (opts?.evalIds && opts.evalIds.length > 0) {
+        conditions.push(
+          `eval_id IN (${opts.evalIds.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.evalIds);
+      }
+
+      if (opts?.order !== undefined) {
+        conditions.push(`col_order = $${++paramIdx}`);
+        values.push(opts.order);
+      }
+
+      if (opts?.statuses && opts.statuses.length > 0) {
+        conditions.push(
+          `status IN (${opts.statuses.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.statuses);
+      }
+
+      const rows = await this.sql.unsafe(
+        `SELECT * FROM results WHERE ${conditions.join(" AND ")} ORDER BY col_order ASC`,
+        values as never[]
+      );
+
+      return rows.map((r) => this.mapResultRow(r));
+    },
+  };
+
+  scores = {
+    create: async (
+      opts: Evalite.Storage.Scores.CreateOpts
+    ): Promise<Evalite.Storage.Entities.Score> => {
+      const [row] = await this.sql`
+        INSERT INTO scores (result_id, name, score, description, metadata)
+        VALUES (${opts.resultId}, ${opts.name}, ${opts.score}, ${opts.description ?? null}, ${this.json(opts.metadata)})
+        RETURNING *
+      `;
+      return this.mapScoreRow(row!);
+    },
+
+    getMany: async (
+      opts?: Evalite.Storage.Scores.GetManyOpts
+    ): Promise<Evalite.Storage.Entities.Score[]> => {
+      const conditions: string[] = ["1=1"];
+      const values: (string | number)[] = [];
+      let paramIdx = 0;
+
+      if (opts?.ids && opts.ids.length > 0) {
+        conditions.push(
+          `id IN (${opts.ids.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.ids);
+      }
+
+      if (opts?.resultIds && opts.resultIds.length > 0) {
+        conditions.push(
+          `result_id IN (${opts.resultIds.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.resultIds);
+      }
+
+      const rows = await this.sql.unsafe(
+        `SELECT * FROM scores WHERE ${conditions.join(" AND ")}`,
+        values as never[]
+      );
+
+      return rows.map((r) => this.mapScoreRow(r));
+    },
+  };
+
+  traces = {
+    create: async (
+      opts: Evalite.Storage.Traces.CreateOpts
+    ): Promise<Evalite.Storage.Entities.Trace> => {
+      const [row] = await this.sql`
+        INSERT INTO traces (result_id, input, output, start_time, end_time, input_tokens, output_tokens, total_tokens, col_order)
+        VALUES (
+          ${opts.resultId},
+          ${this.json(opts.input)},
+          ${this.json(opts.output)},
+          ${Math.round(opts.start)},
+          ${Math.round(opts.end)},
+          ${opts.inputTokens ?? null},
+          ${opts.outputTokens ?? null},
+          ${opts.totalTokens ?? null},
+          ${opts.order}
+        )
+        RETURNING *
+      `;
+      return this.mapTraceRow(row!);
+    },
+
+    getMany: async (
+      opts?: Evalite.Storage.Traces.GetManyOpts
+    ): Promise<Evalite.Storage.Entities.Trace[]> => {
+      const conditions: string[] = ["1=1"];
+      const values: (string | number)[] = [];
+      let paramIdx = 0;
+
+      if (opts?.ids && opts.ids.length > 0) {
+        conditions.push(
+          `id IN (${opts.ids.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.ids);
+      }
+
+      if (opts?.resultIds && opts.resultIds.length > 0) {
+        conditions.push(
+          `result_id IN (${opts.resultIds.map(() => `$${++paramIdx}`).join(",")})`
+        );
+        values.push(...opts.resultIds);
+      }
+
+      const rows = await this.sql.unsafe(
+        `SELECT * FROM traces WHERE ${conditions.join(" AND ")} ORDER BY col_order ASC`,
+        values as never[]
+      );
+
+      return rows.map((r) => this.mapTraceRow(r));
+    },
+  };
+
+  async close(): Promise<void> {
+    await this.sql.end();
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+}
+
+/**
+ * Create a new Postgres storage backend for evalite.
+ *
+ * @param connectionString - Postgres connection string (e.g. postgresql://user:pass@host:5432/db)
+ * @param opts - Optional configuration (schema, table names)
+ * @returns A new PostgresStorage instance
+ *
+ * @example
+ * ```ts
+ * import { createPostgresStorage } from "evalite/postgres-storage";
+ *
+ * export default defineConfig({
+ *   storage: () => createPostgresStorage(process.env.DATABASE_URL!, {
+ *     schema: "evals",
+ *   }),
+ * });
+ * ```
+ */
+export const createPostgresStorage = async (
+  connectionString: string,
+  opts?: PostgresStorageOpts
+): Promise<PostgresStorage> => {
+  const pgModule = await import("postgres");
+  const pg = pgModule.default;
+  const schema = opts?.schema ?? "evals";
+  const sql = pg(connectionString, {
+    connection: { search_path: `${schema},public` },
+  });
+  return PostgresStorage.create(sql, opts);
+};

--- a/packages/evalite/src/storage/test-utils.ts
+++ b/packages/evalite/src/storage/test-utils.ts
@@ -22,6 +22,18 @@ const ADAPTERS_TO_TEST: StorageTestFactory[] = [
   },
 ];
 
+// Conditionally add Postgres adapter when a connection string is available
+if (process.env.EVALITE_TEST_POSTGRES_URL) {
+  const { createPostgresStorage } = await import("./postgres.js");
+  ADAPTERS_TO_TEST.push({
+    name: "PostgresStorage",
+    factory: async () =>
+      createPostgresStorage(process.env.EVALITE_TEST_POSTGRES_URL!, {
+        schema: "evals_test",
+      }),
+  });
+}
+
 /**
  * Test utility that runs the same test suite against all registered storage.
  * Each test will be run with `it.each` for every storage in ADAPTERS_TO_TEST.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
+      postgres:
+        specifier: ^3.0.0
+        version: 3.4.9
       table:
         specifier: ^6.9.0
         version: 6.9.0
@@ -5033,6 +5036,10 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
+    engines: {node: '>=12'}
 
   prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
@@ -11754,6 +11761,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres@3.4.9: {}
 
   prebuild-install@7.1.2:
     dependencies:


### PR DESCRIPTION
# Summary

Implements the Postgres storage adapter requested in #222. Enables persisting eval results to PostgreSQL for team-wide visibility and CI/CD durability.

* Add createPostgresStorage() in evalite/postgres-storage implementing the full Evalite.Storage interface
* Support both connection string and individual connection parameters (host, port, database, user, password, ssl, maxConnections)
* Use [postgres.js](https://github.com/porsager/postgres) as an optional peer dependency — zero native deps, native JSONB handling
* Register in multi-adapter test suite (conditional on EVALITE_TEST_POSTGRES_URL)
* Add Storage guide to docs with DDL, config examples, and options reference
Include minor changeset

## Design decisions

- No auto-migration — consumers provide their own DDL (documented in the storage guide)
- search_path set at connection level — ensures all connections in the pool resolve unqualified table names correctly
- undefined → null coercion for JSON fields — postgres.js rejects undefined values, so the adapter normalizes them

## Test plan

- [ ]  pnpm run ci passes (build, 160 unit tests, lint, format)
- [ ]  With EVALITE_TEST_POSTGRES_URL set, all 70 storage tests pass against Postgres alongside SQLite and InMemory
- [ ]  evalite run persists results to Postgres and evalite serve reads them back in the UI
- [ ]  Docs preview: Storage guide renders correctly in sidebar under Guides > Storage

Closes #222