### PR TITLE
Upgrade better sqlite3 (arm ci improvement)

### DIFF
--- a/.changeset/stale-mangos-sing.md
+++ b/.changeset/stale-mangos-sing.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Upgrade better sqlite3 (arm ci improvement)

--- a/apps/evalite-ui/app/data/use-subscribe-to-socket.ts
+++ b/apps/evalite-ui/app/data/use-subscribe-to-socket.ts
@@ -11,9 +11,7 @@ export const useSubscribeToSocket = (queryClient: QueryClient) => {
       return;
     }
 
-    const socket = new WebSocket(
-      `${window.location.origin}/api/socket`
-    );
+    const socket = new WebSocket(`${window.location.origin}/api/socket`);
 
     socket.onmessage = async (event) => {
       const newState: Evalite.ServerState = JSON.parse(event.data);

--- a/packages/evalite/package.json
+++ b/packages/evalite/package.json
@@ -55,7 +55,7 @@
     "@stricli/core": "^1.2.0",
     "@vitest/runner": "^4.0.0",
     "@vitest/utils": "^4.0.1",
-    "better-sqlite3": "^11.6.0",
+    "better-sqlite3": "^12.9.0",
     "fastify": "^5.6.1",
     "file-type": "^19.6.0",
     "jiti": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,8 +227,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       better-sqlite3:
-        specifier: ^11.6.0
-        version: 11.6.0
+        specifier: ^12.9.0
+        version: 12.9.0
       fastify:
         specifier: ^5.6.1
         version: 5.6.1
@@ -2826,8 +2826,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.6.0:
-    resolution: {integrity: sha512-2J6k/eVxcFYY2SsTxsXrj6XylzHWPxveCn4fKPKZFv/Vqn/Cd7lOuX4d7rGQXT5zL+97MkNL3nSbCrIoe3LkgA==}
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -8965,7 +8966,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.6.0:
+  better-sqlite3@12.9.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.2


### PR DESCRIPTION
Hi,
my goal with this upgrade is to have an evalite version that don't need a compilation step on linux arm CI runners.

I tested on my project by using pnpm overrides, but though I could send a patch upstream, cheers.
