### PR TITLE
fix(ui): trace-row click navigates to per-trace view

### DIFF
--- a/.changeset/0000-fix-trace-row-link-search-param.md
+++ b/.changeset/0000-fix-trace-row-link-search-param.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Fix: clicking a trace row in the eval detail view now navigates to the per-trace panel. Previously the row's `Link` omitted `search: { trace }`, so the URL never changed and the right panel stayed on the eval-level view. Users had to manually append `?trace=N` to the URL as a workaround.

--- a/apps/evalite-ui/app/routes/suite.$name.eval.$evalIndex.tsx
+++ b/apps/evalite-ui/app/routes/suite.$name.eval.$evalIndex.tsx
@@ -409,6 +409,10 @@ const TraceMenuItem = (props: {
         name: props.name,
         evalIndex: props.evalIndex,
       }}
+      search={(prev) => ({
+        ...prev,
+        trace: props.traceIndex,
+      })}
       className={
         "px-3 py-2 hover:bg-foreground/10 transition-colors border-l-4"
       }


### PR DESCRIPTION
Closes #391

The TraceMenuItem `Link` accepted a `traceIndex` prop but never forwarded it to the route's search params. As a result, clicking a trace row left the URL unchanged and the right-hand panel stayed on the eval-level view; users could only reach the per-trace view by manually editing the URL to add `?trace=N`.

Forward `traceIndex` via TanStack Router's function-form `search` prop so the URL gains `?trace=N` on click while preserving other search params (e.g. `timestamp`). The top "Eval" row has no `traceIndex`, so `trace` becomes `undefined` and is dropped from the URL, returning the view to the eval-level panel. The existing schema already types `trace` as `z.number().optional()`, so no schema change is required.