### PR TITLE
fix: respect `caching: false` on `wrapAISDKModel`

### DIFF
--- a/.changeset/wrap-aisdk-respect-caching-flag.md
+++ b/.changeset/wrap-aisdk-respect-caching-flag.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Fix: `wrapAISDKModel(model, { caching: false })` is now actually respected. Previously the local `caching: false` flag was silently ignored as long as tracing was enabled — the cache was still being read from and written to. The wrapper now skips both cache fetch and store (in `wrapGenerate` and `wrapStream`) when `caching: false` is set.

--- a/packages/evalite-tests/tests/ai-sdk-caching.test.ts
+++ b/packages/evalite-tests/tests/ai-sdk-caching.test.ts
@@ -94,3 +94,26 @@ it("Should let runEvalite cacheEnabled override config cacheEnabled", async () =
   // Should have no cache logs because runEvalite overrides config
   expect(cachelogs.length).toBe(0);
 });
+
+it("Should respect caching: false on wrapAISDKModel even when global cache is enabled", async () => {
+  await using fixture = await loadFixture("ai-sdk-caching-local-disabled");
+
+  // Two runs with the same input. Global cache is enabled (default), but each
+  // model is wrapped with `wrapAISDKModel(..., { caching: false })`, so neither
+  // run should fetch or store anything in the cache.
+  await fixture.run({
+    mode: "run-once-and-exit",
+    cacheDebug: true,
+    enableServer: true,
+  });
+
+  await fixture.run({
+    mode: "run-once-and-exit",
+    cacheDebug: true,
+    enableServer: true,
+  });
+
+  const allLogs = fixture.getOutput().split("\n");
+  const cachelogs = allLogs.filter((log) => log.includes("[CACHE]"));
+  expect(cachelogs.length).toBe(0);
+});

--- a/packages/evalite-tests/tests/fixtures/ai-sdk-caching-local-disabled/caching.eval.ts
+++ b/packages/evalite-tests/tests/fixtures/ai-sdk-caching-local-disabled/caching.eval.ts
@@ -1,0 +1,75 @@
+import { generateText } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { wrapAISDKModel } from "evalite/ai-sdk";
+import { evalite } from "evalite";
+
+const model = new MockLanguageModelV3({
+  doGenerate: {
+    finishReason: { unified: "stop", raw: undefined },
+    usage: {
+      inputTokens: {
+        total: 10,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 20, text: undefined, reasoning: undefined },
+    },
+    content: [{ type: "text", text: `Response for task` }],
+    warnings: [],
+  },
+});
+
+const scorerModel = new MockLanguageModelV3({
+  doGenerate: {
+    finishReason: { unified: "stop", raw: undefined },
+    usage: {
+      inputTokens: {
+        total: 5,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 10, text: undefined, reasoning: undefined },
+    },
+    content: [{ type: "text", text: `1` }],
+    warnings: [],
+  },
+});
+
+const tracedModel = wrapAISDKModel(model, { caching: false });
+const tracedScorerModel = wrapAISDKModel(scorerModel, { caching: false });
+
+evalite("AI SDK Caching Local Disabled", {
+  data: () => {
+    return [
+      {
+        input: "test input 1",
+        expected: "expected output 1",
+      },
+      {
+        input: "test input 2",
+        expected: "expected output 2",
+      },
+    ];
+  },
+  task: async (input) => {
+    const result = await generateText({
+      model: tracedModel,
+      prompt: input,
+    });
+    return result.text;
+  },
+  scorers: [
+    {
+      name: "AI Scorer",
+      scorer: async ({ input, output, expected }) => {
+        const result = await generateText({
+          model: tracedScorerModel,
+          prompt: `Score this: ${output}`,
+        });
+        return { score: 1 };
+      },
+    },
+  ],
+});

--- a/packages/evalite/src/ai-sdk.ts
+++ b/packages/evalite/src/ai-sdk.ts
@@ -113,7 +113,7 @@ export const wrapAISDKModel = (
         const cacheContext = getCacheContext();
 
         // Try cache if enabled
-        if (cacheContext) {
+        if (cacheContext && enableCaching) {
           const keyHash = generateCacheKey({
             model: modelId,
             params: opts.params,
@@ -163,7 +163,7 @@ export const wrapAISDKModel = (
           const duration = performance.now() - start;
 
           // Store in cache if caching enabled
-          if (cacheContext) {
+          if (cacheContext && enableCaching) {
             const keyHash = generateCacheKey({
               model: modelId,
               params: opts.params,
@@ -237,7 +237,7 @@ export const wrapAISDKModel = (
         const reportTraceFromContext = reportTraceLocalStorage.getStore();
 
         // Try cache if enabled
-        if (cacheContext) {
+        if (cacheContext && enableCaching) {
           const keyHash = generateCacheKey({
             model: modelId,
             params: params,
@@ -318,7 +318,7 @@ export const wrapAISDKModel = (
               const duration = performance.now() - start;
 
               // Store in cache if enabled
-              if (cacheContext) {
+              if (cacheContext && enableCaching) {
                 const keyHash = generateCacheKey({
                   model: modelId,
                   params: params,


### PR DESCRIPTION
## What

Fix the `caching: false` option on `wrapAISDKModel`, which was silently ignored.

Closes #395.

## Why

`wrapAISDKModel(model, { caching: false })` reads the flag at the top of the function but never checks it inside the wrapper. The cache fetch and store paths are gated only on `if (cacheContext)`, so as long as tracing is enabled (default), the cache is read and written regardless of what the user passed.

This is misleading: the API suggests opt-out is supported, but the only way to truly bypass the cache today is to also disable tracing (which makes `wrapAISDKModel` short-circuit and return the unwrapped model). Users running cross-model baselines or measuring sampling variability across `trialCount > 1` silently get cached responses.

## Change

Four sites in `packages/evalite/src/ai-sdk.ts` — two in `wrapGenerate`, two in `wrapStream`:

```diff
-if (cacheContext) {
+if (cacheContext && enableCaching) {
```

The early-return `if (!enableCaching && !enableTracing) return model;` is unchanged. Tracing path is untouched. When `caching: true` (default), behavior is identical to before.

## Tests

- All four existing `ai-sdk-caching.test.ts` tests still pass.
- New test added: `Should respect caching: false on wrapAISDKModel even when global cache is enabled`.
- New fixture: `packages/evalite-tests/tests/fixtures/ai-sdk-caching-local-disabled/` — same shape as `ai-sdk-caching` but wraps both task and scorer models with `{ caching: false }`. Asserts that two consecutive runs produce zero `[CACHE]` log lines, demonstrating that neither cache fetch nor store happened.

```
✓ tests/ai-sdk-caching.test.ts (5 tests) 2887ms
   ✓ Should cache AI SDK in the task and scorers
   ✓ Should disable cache when cacheEnabled is false
   ✓ Should respect cacheEnabled: false in config
   ✓ Should let runEvalite cacheEnabled override config cacheEnabled
   ✓ Should respect caching: false on wrapAISDKModel even when global cache is enabled
```

## Changeset

`patch` bump for `evalite`. See `.changeset/wrap-aisdk-respect-caching-flag.md`.

## Out of scope (mentioned for context)

The companion bug — that the CLI flag `--no-cache` and config `cache: false` only short-circuit the `reportCacheHit` callback in `evalite.ts` rather than skipping the `cacheContextLocalStorage.enterWith()` call — is not addressed here. That's a more invasive change touching `evalite.ts` + types, and I think it deserves its own PR. Happy to follow up if you'd like; flagged as a note in #395.
