### PR TITLE
chore: add evalite package license metadata

### DIFF
--- a/packages/evalite/package.json
+++ b/packages/evalite/package.json
@@ -2,6 +2,7 @@
   "name": "evalite",
   "version": "0.19.0",
   "type": "module",
+  "license": "MIT",
   "description": "Test your LLM-powered apps with a TypeScript-native, Vitest-based eval runner. No API key required.",
   "homepage": "https://evalite.dev",
   "keywords": [


### PR DESCRIPTION
Summary:
- Add MIT license metadata to the published evalite package manifest.

Validation:
- node package metadata assertion
- npm pack --dry-run --json --ignore-scripts in packages/evalite
- git diff --check