### PR TITLE
fix: declare vitest dependency

### DIFF
--- a/.changeset/calm-waves-sip.md
+++ b/.changeset/calm-waves-sip.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Declare Vitest as an Evalite runtime dependency.

--- a/packages/evalite/package.json
+++ b/packages/evalite/package.json
@@ -67,7 +67,8 @@
     "jiti": "^2.6.1",
     "js-levenshtein": "^1.1.6",
     "table": "^6.9.0",
-    "tinyrainbow": "^3.0.3"
+    "tinyrainbow": "^3.0.3",
+    "vitest": "^4.0.0"
   },
   "peerDependencies": {
     "better-sqlite3": "^11.6.0",

--- a/packages/evalite/src/command.test.ts
+++ b/packages/evalite/src/command.test.ts
@@ -1,6 +1,19 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vitest } from "vitest";
 import { createProgram } from "./command.js";
 import { run } from "@stricli/core";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8")
+) as {
+  dependencies?: Record<string, string>;
+};
+
+describe("package manifest", () => {
+  it("declares vitest as a runtime dependency", () => {
+    expect(packageJson.dependencies).toHaveProperty("vitest");
+  });
+});
 
 describe("createCommand", () => {
   it("evalite without path", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       tinyrainbow:
         specifier: ^3.0.3
         version: 3.0.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.1(@types/debug@4.1.12)(@types/node@22.7.7)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.3(@types/node@22.7.7)(typescript@5.9.3))(terser@5.31.5)(tsx@4.19.3)(yaml@2.8.1)
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^3.0.0


### PR DESCRIPTION
`evalite` imports from `vitest` at runtime, but the published package did not declare `vitest`, so strict pnpm/no-hoist installs could fail resolution. This declares `vitest` in the Evalite package dependencies, while leaving the existing Vitest utility packages and peer dependencies unchanged. I added a manifest assertion that failed before the dependency was declared, then ran `pnpm run build:evalite`, `pnpm --filter evalite test -- src/command.test.ts`, `pnpm --filter evalite-tests test -- tests/basics.test.ts`, typecheck, lint, format, and `pnpm run ci`.

Fixes #398
