### PR TITLE
Fix --hideTable forwarding in run and serve modes

### DIFF
--- a/.changeset/hide-table-forwarding.md
+++ b/.changeset/hide-table-forwarding.md
@@ -1,0 +1,5 @@
+---
+"evalite": patch
+---
+
+Fix `--hideTable` so it suppresses terminal result tables in run and serve modes.

--- a/packages/evalite/src/command.test.ts
+++ b/packages/evalite/src/command.test.ts
@@ -1,6 +1,41 @@
 import { describe, expect, it, vitest } from "vitest";
-import { createProgram } from "./command.js";
+import { createProgram, program } from "./command.js";
 import { run } from "@stricli/core";
+import { runEvalite } from "./run-evalite.js";
+
+vitest.mock("./run-evalite.js", () => ({
+  runEvalite: vitest.fn(),
+}));
+
+describe("program", () => {
+  it("forwards --hideTable to runEvalite in serve mode", async () => {
+    await run(program, ["serve", "--hideTable"], { process });
+
+    expect(runEvalite).toHaveBeenCalledWith({
+      path: undefined,
+      scoreThreshold: undefined,
+      cwd: undefined,
+      mode: "run-once-and-serve",
+      outputPath: undefined,
+      hideTable: true,
+      cacheEnabled: undefined,
+    });
+  });
+
+  it("forwards --hideTable to runEvalite in run mode", async () => {
+    await run(program, ["--hideTable"], { process });
+
+    expect(runEvalite).toHaveBeenCalledWith({
+      path: undefined,
+      scoreThreshold: undefined,
+      cwd: undefined,
+      mode: "run-once-and-exit",
+      outputPath: undefined,
+      hideTable: true,
+      cacheEnabled: undefined,
+    });
+  });
+});
 
 describe("createCommand", () => {
   it("evalite without path", async () => {

--- a/packages/evalite/src/command.ts
+++ b/packages/evalite/src/command.ts
@@ -223,6 +223,7 @@ export const program = createProgram({
       cwd: undefined,
       mode: "run-once-and-exit",
       outputPath: path.outputPath,
+      hideTable: path.hideTable,
       cacheEnabled: path.noCache ? false : undefined,
     });
   },
@@ -233,6 +234,7 @@ export const program = createProgram({
       cwd: undefined,
       mode: "run-once-and-serve",
       outputPath: path.outputPath,
+      hideTable: path.hideTable,
       cacheEnabled: path.noCache ? false : undefined,
     });
   },


### PR DESCRIPTION
## Summary

- forward the parsed `--hideTable` option to `runEvalite` in run and serve modes
- add regression tests for both command paths
- add a patch changeset for `evalite`

## Root cause and impact

The CLI parser captured `hideTable`, but the run and serve command wrappers omitted it when constructing the options passed to `runEvalite`.

As a result, the reporter continued printing the detailed task-results table even when `evalite serve --hideTable` was used. This is especially noisy for large eval suites that use the UI to inspect results.

## Validation

- 102 Evalite source tests passed
- typecheck passed
- ESLint passed
- Prettier passed

Fixes #393